### PR TITLE
Update setup.py to remove version duplication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,44 @@
+"""Install the package."""
+
+import ast
 from setuptools import setup
+
+def get_version(file_name: str, version_variable: str = "__version__") -> str:
+    """Find the version by walking the AST to avoid duplication.
+
+    Parameters
+    ----------
+    file_name : str
+        The file we are parsing to get the version string from.
+    version_variable : str
+        The variable name that holds the version string.
+
+    Raises
+    ------
+    ValueError
+        If there was no assignment to version_variable in file_name.
+
+    Returns
+    -------
+    version_string : str
+        The version string parsed from file_name_name.
+    """
+    with open(file_name) as f:
+        tree = ast.parse(f.read())
+        # Look at all assignment nodes that happen in the ast. If the variable
+        # name matches the given parameter, grab the value (which will be
+        # the version string we are looking for).
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                if node.targets[0].id == version_variable:
+                    return node.value.s
+    raise ValueError(f"Could not find an assignment to {version_variable} "
+                     f"within '{file_name}'")
+
 
 setup(
     name="git_cml",
-    version="0.0.0",
+    version=get_version("git_cml/__init__.py"),
     description="Version control system for model checkpoints.",
     author="Colin Raffel",
     author_email="craffel@gmail.com",
@@ -10,6 +46,7 @@ setup(
     packages=["git_cml"],
     scripts=["bin/git-cml", "bin/git-cml-filter"],
     long_description="Version control system for model checkpoints.",
+    python_requires=">=3.6",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
-"""Install the package."""
+"""Install the git-theta package."""
 
 import ast
 from setuptools import setup
+
 
 def get_version(file_name: str, version_variable: str = "__version__") -> str:
     """Find the version by walking the AST to avoid duplication.
@@ -32,8 +33,9 @@ def get_version(file_name: str, version_variable: str = "__version__") -> str:
             if isinstance(node, ast.Assign):
                 if node.targets[0].id == version_variable:
                     return node.value.s
-    raise ValueError(f"Could not find an assignment to {version_variable} "
-                     f"within '{file_name}'")
+    raise ValueError(
+        f"Could not find an assignment to {version_variable} " f"within '{file_name}'"
+    )
 
 
 setup(


### PR DESCRIPTION
This change addes my well vetted ast parsing solution to finding the version string that lives in the package source code, without needing to have the package installed, allowing for it to be used in setup.py.

Additionally, I added a minimum python version to the setup call. f-strings are used throughout the code base and therefore we need to be using at least python3.6