### PR TITLE
feature: set-up pre-commit hooks for easier tool integration (black)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ git extension for collaborative, continual, and communal model development
 Creation of the model's computational graph, actual usage of the parameters,
 configuration, hyperparameter values, etc. is left up to code
 (which can be versioned in tandem with the checkpoint via git as usual).
-When a checkpoint is staged (added to the repository) via `git-cml`, 
+When a checkpoint is staged (added to the repository) via `git-cml`,
 each parameter "group" (e.g. a weight matrix or a bias vector) is
 given its own directory in `.git_cml/{checkpoint_file_name}/{parameter_name}`.
 The files within the `.git_cml/{checkpoint_file_name}` directory are tracked by git.
@@ -39,3 +39,20 @@ All parameters and updates are currently stored via `git-lfs`.
 `git merge` will assume that all merges to the checkpoint (i.e. to parameter
 group files) result in merge conflicts and offer various possible automated
 merging strategies that can be tried and vetted.
+
+
+# Development Setup
+
+This project uses black for code formatting and includes CI checks for black compliance.
+To configure pre-commit hooks, which will automatically run black against any files
+staged for commit before allowing the commit to happen run the following:
+
+``` sh
+$ pip install -r requirements-dev.txt
+$ pre-commit install
+```
+
+When black must reformat your file, it will show as the black pre-commit hook
+failing. When this happens you will see that the source file has been reformatted
+and is ready to be re-added to the index. Running `git commit` again should
+result in all the hooks passing and the commit actually happening.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
This PR adds pre-commit hooks to enable common tooling integration (for example, automatically run black on files staged for commit to avoid manually running it as mentioned [here](https://github.com/r-three/git-theta/pull/55#issuecomment-1304527634)).

It also adds a quick overview to the read me about how to set this up as a developer git-theta and creates a simple requirements-dev.txt as a method of tracking any developer dependencies (which can be disjoint from the actual library dependencies).

Note: We can see that the pre-commit hook caught and fixed trailing white-space in the README.md lol