### PR TITLE
Chore: Fix program description in argparse.ArgumentParser

### DIFF
--- a/bin/git-cml
+++ b/bin/git-cml
@@ -15,7 +15,7 @@ logging.basicConfig(
 
 
 def parse_args():
-    parser = argparse.ArgumentParser("git-cml filter program")
+    parser = argparse.ArgumentParser(description="git-cml filter program")
     subparsers = parser.add_subparsers(title="Commands", dest="command")
     subparsers.required = True
 
@@ -101,7 +101,7 @@ def add(args):
         param_file = os.path.join(param_dir, "params")
         file_io.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
-    
+
     for param_file in iterate_removed_params(param_dict, cml_model_dir):
         git_utils.remove_file(param_file, repo)
 

--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -20,7 +20,7 @@ logging.basicConfig(
 
 
 def parse_args():
-    parser = argparse.ArgumentParser("git-cml filter program")
+    parser = argparse.ArgumentParser(description="git-cml filter program")
     subparsers = parser.add_subparsers(title="Commands", dest="command")
     subparsers.required = True
 


### PR DESCRIPTION
The description string in argparse.ArgumentParser needs to be a named parameter, otherwise it sets the program name and you get help messages like this:

```
$ git-cml --help
usage: git-cml filter program [-h] {add,install,track} ...
```

Instead of

```
$ git-cml --help
usage: git-cml [-h] {add,install,track} ...
```