### PR TITLE
Fix bug in adding tracking to .gitattributes

### DIFF
--- a/bin/git-cml
+++ b/bin/git-cml
@@ -3,7 +3,6 @@
 import argparse
 import os
 import sys
-import re
 import git
 import logging
 
@@ -101,7 +100,7 @@ def add(args):
         param_file = os.path.join(param_dir, "params")
         file_io.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
-    
+
     for param_file in iterate_removed_params(param_dict, cml_model_dir):
         git_utils.remove_file(param_file, repo)
 
@@ -137,21 +136,9 @@ def track(args):
     gitattributes_file = git_utils.get_gitattributes_file(repo)
     gitattributes = git_utils.read_gitattributes(gitattributes_file)
 
-    pattern_found = False
-    for line in gitattributes:
-        match = re.match("^\s*(?P<pattern>[^\s]+)\s+(?P<attributes>.*)$", line)
-        if match is None:
-            continue
-        if match.group("pattern") != args.file:
-            continue
-        if not "filter=cml" in match.group("attributes"):
-            line += " filter=cml"
-        pattern_found = True
+    new_gitattributes = git_utils.add_filter_cml_to_gitattributes(gitattributes, model_path)
 
-    if not pattern_found:
-        gitattributes.append(f"{model_path} filter=cml")
-
-    git_utils.write_gitattributes(gitattributes_file, gitattributes)
+    git_utils.write_gitattributes(gitattributes_file, new_gitattributes)
     git_utils.add_file(gitattributes_file, repo)
 
 

--- a/git_cml/git_utils.py
+++ b/git_cml/git_utils.py
@@ -1,4 +1,4 @@
-"""Utilitis for manipulating git."""
+"""Utilities for manipulating git."""
 
 import fnmatch
 import git

--- a/git_cml/git_utils.py
+++ b/git_cml/git_utils.py
@@ -1,9 +1,14 @@
+"""Utilitis for manipulating git."""
+
+import fnmatch
 import git
 import os
 import json
 import logging
 import io
+import re
 import torch
+from typing import List
 import subprocess
 
 
@@ -218,3 +223,38 @@ def git_lfs_track(repo, directory):
         ["git", "lfs", "track", f'"{track_glob}"'], cwd=repo.working_dir
     )
     return out.returncode
+
+
+def add_filter_cml_to_gitattributes(gitattributes: List[str], path: str) -> str:
+    """Add a filter=cml that covers file_name.
+
+    Parameters
+    ----------
+        gitattributes: A list of the lines from the gitattribute files.
+        path: The path to the model we are adding a filter to.
+
+    Returns
+    -------
+    List[str]
+        The lines to write to the new gitattribute file with a (possibly) new
+        filter=cml added that covers the given file.
+    """
+    pattern_found = False
+    new_gitattributes = []
+    for line in gitattributes:
+        # TODO(bdlester): Revisit this regex to see if it when the pattern
+        # is escaped due to having spaces in it.
+        match = re.match("^\s*(?P<pattern>[^\s]+)\s+(?P<attributes>.*)$", line)
+        if match:
+            # If there is already a pattern that covers the file, add the filter
+            # to that.
+            if fnmatch.fnmatchcase(path, match.group("pattern")):
+                pattern_found = True
+                if not "filter=cml" in match.group("attributes"):
+                    line = f"{line.rstrip()} filter=cml\n"
+        new_gitattributes.append(line)
+    # If we don't find a matching pattern, add a new line that covers just this
+    # specific file.
+    if not pattern_found:
+        new_gitattributes.append(f"{path} filter=cml\n")
+    return new_gitattributes

--- a/tests/git_utils_test.py
+++ b/tests/git_utils_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+from git_cml import git_utils
+
+
+def test_add_filter_gitattributes_empty_file():
+    assert git_utils.add_filter_cml_to_gitattributes([], "example") == [
+        "example filter=cml\n"
+    ]
+
+
+def test_add_filter_gitattributes_no_match():
+    atts = [
+        "Some-other-path filter=lfs\n",
+        "*-cool-models.pt filter=cml\n",
+    ]
+    model_path = "path/to/my/model.pt"
+    assert (
+        git_utils.add_filter_cml_to_gitattributes(atts, model_path)[-1]
+        == f"{model_path} filter=cml\n"
+    )
+
+
+def test_add_filter_gitattributes_exact_match():
+    model_path = "really/cool/model/yall.ckpt"
+    atts = [f"{model_path} filter=lfs\n"]
+    assert (
+        git_utils.add_filter_cml_to_gitattributes(atts, model_path)[-1]
+        == f"{model_path} filter=lfs filter=cml\n"
+    )
+
+
+def test_add_filter_gitattributes_pattern_match():
+    model_path = "literal-the-best-checkpoint.pt"
+    atts = ["*.pt thing\n"]
+    assert (
+        git_utils.add_filter_cml_to_gitattributes(atts, model_path)[-1]
+        == f"*.pt thing filter=cml\n"
+    )
+
+
+def test_add_filter_gitattributes_multiple_matches():
+    model_path = "100-on-mnist.npy"
+    atts = ["*.npy\n", f"{model_path}\n"]
+    assert git_utils.add_filter_cml_to_gitattributes(atts, model_path) == [
+        "*.npy filter=cml\n",
+        f"{model_path} filter=cml\n",
+    ]
+
+
+def test_add_filter_gitattributes_match_with_cml_already():
+    model_path = "my-bad-model.chkp"
+    atts = ["my-*-model.chkp filter=cml"]
+    assert git_utils.add_filter_cml_to_gitattributes(atts, model_path) == atts
+
+
+def test_add_filter_gitattributes_rest_unchanged():
+    model_path = "model-v3.pt"
+    atts = [
+        "some-other-path filter=cml\n",
+        "really-reaaaally-big-files filter=lfs\n",
+        r"model-v\d.pt\n",
+        "another filter=cml\n",
+    ]
+    results = git_utils.add_filter_cml_to_gitattributes(atts, model_path)
+    for i, (a, r) in enumerate(zip(atts, results)):
+        if i == 2:
+            continue
+        assert a == r
+
+
+def test_add_filter_gitattributes_all_newlines():
+    atts = [f"{x}\n" for x in list("abcdef")]
+    for gitattr in git_utils.add_filter_cml_to_gitattributes(atts, "b"):
+        assert gitattr.endswith("\n")


### PR DESCRIPTION
The git cml track command has a bug where `filter=cml` wasn't added to lines that matched the provided file path. The issue was that python strings are immutable, so the `+=` that was used to append `filter=cml` results in just updating the string reference stored in the the iteration variable which is lost in the next step of the loop and the the change is lost.

Additionally, it fixes a bug where adding `filter=cml` (if it had worked) would have been added after the newline.

It also updates the pattern matching comparing the gitattributes pattern to the model path to use `fnmatch.fnmatchcase`, which evaluates glob matches, instead of a direct comparison. This means we no longer add the model path if it is already covered by some other pattern.

It also extracts the logic into a utility function which I added untitests for as it can now be tested independent of any actual `.gitattributes` file.