### PR TITLE
Move logging to lazy string interpolation

### DIFF
--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -40,7 +40,7 @@ def clean(args):
     """
     Implements clean filter for model files
     """
-    logging.debug(f"Running clean filter on {args.file}")
+    logging.debug("Running clean filter on %s", args.file)
 
     repo = git_utils.get_git_repo()
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
@@ -61,7 +61,7 @@ def smudge(args):
     """
     Implements smudge filter for model files
     """
-    logging.debug(f"Running smudge filter on {args.file}")
+    logging.debug("Running smudge filter on %s", args.file)
 
     repo = git_utils.get_git_repo()
     staged_file = file_io.load_staged_file(sys.stdin)
@@ -71,7 +71,7 @@ def smudge(args):
         os.path.abspath(staged_file["model_dir"])
     ):
         param_file = os.path.join(leaf_dir, "params")
-        logging.debug(f"Populating model parameter {'/'.join(keys)}")
+        logging.debug("Populating model parameter %s", '/'.join(keys))
         d = model_dict
         for k in keys[:-1]:
             d = d[k]

--- a/git_cml/file_io.py
+++ b/git_cml/file_io.py
@@ -19,7 +19,7 @@ def load_tracked_file(f):
         numpy array stored in tracked file
 
     """
-    logging.debug(f"Loading tracked file {f}")
+    logging.debug("Loading tracked file %s", f)
     ts_file = ts.open(
         {
             "driver": "zarr",
@@ -45,7 +45,7 @@ def write_tracked_file(f, param):
         param value to dump to file
 
     """
-    logging.debug(f"Dumping param to {f}")
+    logging.debug(f"Dumping param to %s", f)
     ts_file = ts.open(
         {
             "driver": "zarr",

--- a/git_cml/git_utils.py
+++ b/git_cml/git_utils.py
@@ -38,7 +38,7 @@ def get_git_cml(repo, create=False):
     """
     git_cml = os.path.join(repo.working_dir, ".git_cml")
     if not os.path.exists(git_cml) and create:
-        logging.debug(f"Creating git cml directory {git_cml}")
+        logging.debug("Creating git cml directory %s", git_cml)
         os.makedirs(git_cml)
     return git_cml
 
@@ -67,7 +67,7 @@ def get_git_cml_model_dir(repo, model_path, create=False):
     git_cml_model_dir = os.path.join(git_cml, model_path)
 
     if not os.path.exists(git_cml_model_dir) and create:
-        logging.debug(f"Creating model directory {git_cml_model_dir}")
+        logging.debug("Creating model directory %s", git_cml_model_dir)
         os.makedirs(git_cml_model_dir)
 
     return git_cml_model_dir
@@ -160,7 +160,7 @@ def add_file(f, repo):
     repo : git.Repo
         Repo object for current git repository
     """
-    logging.debug(f"Adding {f} to staging area")
+    logging.debug("Adding %s to staging area", f)
     repo.git.add(f)
 
 
@@ -175,7 +175,7 @@ def remove_file(f, repo):
     repo : git.Repo
         Repo object for current git repository
     """
-    logging.debug(f"Removing {f}")
+    logging.debug("Removing %s", f)
     if os.path.isdir(f):
         repo.git.rm("-r", f)
     else:


### PR DESCRIPTION
When logging, especially at a lower level like debug, there is often a pretty good chance that a log message will never actually get emitted. Using a lazy logging formatter like % instead of eager f-strings means the interpolation won't actually happen until we know the log will actually get emitted.