### PR TITLE
Simplify file/path polymorphism

### DIFF
--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -5,6 +5,8 @@ import os
 import json
 import io
 
+from file_or_name import file_or_name
+
 # Maintain access via checkpoints module for now.
 from .utils import iterate_dict_leaves
 
@@ -54,6 +56,7 @@ class PyTorchCheckpoint(Checkpoint):
     """Class for wrapping PyTorch checkpoints."""
 
     @classmethod
+    @file_or_name(checkpoint_path="rb")
     def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
 
@@ -67,10 +70,7 @@ class PyTorchCheckpoint(Checkpoint):
         model_dict : dict
             Dictionary mapping parameter names to parameter values
         """
-        if isinstance(checkpoint_path, io.IOBase):
-            checkpoint_path = io.BytesIO(checkpoint_path.read())
-
-        model_dict = torch.load(checkpoint_path)
+        model_dict = torch.load(io.BytesIO(checkpoint_path.read()))
         if not isinstance(model_dict, dict):
             raise ValueError("Supplied PyTorch checkpoint must be a dict.")
         if not all(isinstance(k, str) for k in model_dict.keys()):
@@ -95,6 +95,7 @@ class JSONCheckpoint(Checkpoint):
     """Class for prototyping with JSON checkpoints"""
 
     @classmethod
+    @file_or_name(checkpoint_path="r")
     def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
 
@@ -108,12 +109,9 @@ class JSONCheckpoint(Checkpoint):
         model_dict : dict
             Dictionary mapping parameter names to parameter values
         """
-        if isinstance(checkpoint_path, io.IOBase):
-            return json.load(checkpoint_path)
-        else:
-            with open(checkpoint_path, "r") as f:
-                return json.load(f)
+        return json.load(checkpoint_path)
 
+    @file_or_name(checkpoint_path="w")
     def save(self, checkpoint_path):
         """Load a checkpoint into a dict format.
 
@@ -122,11 +120,7 @@ class JSONCheckpoint(Checkpoint):
         checkpoint_path : str or file-like object
             Path to write out the checkpoint file to
         """
-        if isinstance(checkpoint_path, io.IOBase):
-            json.dump(self, checkpoint_path)
-        else:
-            with open(checkpoint_path, "w") as f:
-                json.dump(self, f)
+        json.dump(self, checkpoint_path)
 
 
 def iterate_dir_leaves(root):

--- a/git_theta/file_io.py
+++ b/git_theta/file_io.py
@@ -3,6 +3,8 @@ import io
 import json
 import logging
 
+from file_or_name import file_or_name
+
 
 def load_tracked_file(f):
     """
@@ -64,6 +66,7 @@ def write_tracked_file(f, param):
     return ts_file.write(param).result()
 
 
+@file_or_name
 def load_staged_file(f):
     """
     Load staged file
@@ -78,13 +81,10 @@ def load_staged_file(f):
     dict
         staged file contents
     """
-    if isinstance(f, io.IOBase):
-        return json.load(f)
-    else:
-        with open(f, "r") as f:
-            return json.load(f)
+    return json.load(f)
 
 
+@file_or_name(f="w")
 def write_staged_file(f, contents):
     """
     Write staged file
@@ -96,8 +96,4 @@ def write_staged_file(f, contents):
     contents : dict
         dictionary to write to staged file
     """
-    if isinstance(f, io.IOBase):
-        json.dump(contents, f, indent=4)
-    else:
-        with open(f, "w") as f:
-            json.dump(contents, f, indent=4)
+    json.dump(contents, f, indent=4)

--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -8,8 +8,10 @@ import logging
 import io
 import re
 import torch
-from typing import List
+from typing import List, Union
 import subprocess
+
+from file_or_name import file_or_name
 
 
 def get_git_repo():
@@ -138,20 +140,22 @@ def read_gitattributes(gitattributes_file):
         return []
 
 
-def write_gitattributes(gitattributes_file, attributes):
+@file_or_name(gitattributes_file="w")
+def write_gitattributes(
+    gitattributes_file: Union[str, io.FileIO], attributes: List[str]
+):
     """
     Write list of attributes to this repo's .gitattributes file
 
     Parameters
     ----------
-    gitattributes_file : str
+    gitattributes_file:
         Path to this repo's .gitattributes file
 
-    attributes : List[str]
+    attributes:
         Attributes to write to .gitattributes
     """
-    with open(gitattributes_file, "w") as f:
-        f.writelines(attributes)
+    gitattributes_file.writelines(attributes)
 
 
 def add_file(f, repo):

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "GitPython",
         "torch",
         "tensorstore",
+        "file-or-name",
     ],
     extras_require={
         "test": ["pytest"],


### PR DESCRIPTION
This PR simplifies the handing of files vs path strings (or pathlib objects) using my file_or_name library. There are several edge cases (related to file closing, non-positional parameters, and generators) that my library tests. Therefore I opted to make it as a dependency instead of vendoring it into the code base. We can revisit this if people want.

Note: The `read_gitattributes` function assumes that the parameter is only a string and additionally handles what to do when the file is missing. There for it was not a good candidate to be decorated with this file opener.

Closes https://github.com/r-three/git-theta/issues/63