### PR TITLE
Feat/flat maps

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -61,7 +61,7 @@ def add(args):
         file_io.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
 
-    for param_file in utils.removed_params(param_dict, utils.walk_dir(theta_model_dir)):
+    for param_file in utils.removed_params(param_dict, utils.walk_parameter_dir(theta_model_dir)):
         git_utils.remove_file(param_file, repo)
 
     git_utils.add_file(model_path, repo)

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -44,7 +44,7 @@ def parse_args():
 
 def paths_and_parameters(model_dict, root):
     """Convert the keys of the model dict to parameters based starting at root."""
-    return {os.path.join(root, "/".join(k)): v for k, v in utils.flatten(model_dict).items()}
+    return {os.path.join(root, *k): v for k, v in utils.flatten(model_dict).items()}
 
 
 def add(args):

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -6,7 +6,7 @@ import sys
 import git
 import logging
 
-from git_theta import git_utils, checkpoints, file_io
+from git_theta import git_utils, checkpoints, file_io, utils
 
 logging.basicConfig(
     level=logging.DEBUG, format="git-theta: [%(asctime)s] %(levelname)s - %(message)s"
@@ -42,49 +42,8 @@ def parse_args():
     return args
 
 
-def iterate_dict_and_dir_leaves(d, root):
-    """
-    Generator that iterates through dictionary leaves and produces (param, param_file) tuples where param is a dictionary leaf
-    and param_file is the file below root corresponding to the sequence of keys used to access the dictionary leaf. Each subdirectory
-    between root and param_file is created if it does not exist.
-
-    Example
-    -------
-    d = {'a': {'b': {'c': 10, 'd': 20, 'e': 30}}}
-    root = 'rootdir'
-    iterate_dict_and_dir_leaves(d, root) --> ((10, 'rootdir/a/b/c'), (20, 'rootdir/a/b/d'), (30, 'rootdir/a/b/e'))
-
-    Parameters
-    ----------
-    d : dict
-        dictionary to iterate over
-    root : str
-        path to root directory where directory tree representing `d` is created
-    """
-    for leaf, keys in checkpoints.iterate_dict_leaves(d):
-        param_dir = os.path.join(root, "/".join(keys))
-        if not os.path.exists(param_dir):
-            os.makedirs(param_dir)
-        yield leaf, param_dir
-
-
-def iterate_removed_params(d, root):
-    """
-    Generator that iterates a model directory and yields the parameter groups that are present in the model directory but not in the model dictionary
-
-    Example
-    -------
-
-    Parameters
-    ----------
-    """
-    for leaf, keys in checkpoints.iterate_dir_leaves(root):
-        curr_d = d
-        for k in keys:
-            if curr_d.get(k) is None:
-                yield leaf
-                continue
-            curr_d = curr_d[k]
+def paths_and_parameters(model_dict, root):
+    return {os.path.join(root, "/".join(k)): v for k, v in utils.flatten(model_dict).items()}
 
 
 def add(args):
@@ -96,12 +55,13 @@ def add(args):
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
     param_dict = checkpoints.PyTorchCheckpoint.from_file(args.file)
-    for (param, param_dir) in iterate_dict_and_dir_leaves(param_dict, theta_model_dir):
+    for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
+        os.makedirs(param_file, exist_ok=True)
         file_io.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
 
-    for param_file in iterate_removed_params(param_dict, theta_model_dir):
+    for param_file in utils.removed_params(param_dict, utils.walk_dir(theta_model_dir)):
         git_utils.remove_file(param_file, repo)
 
     git_utils.add_file(model_path, repo)

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -43,6 +43,7 @@ def parse_args():
 
 
 def paths_and_parameters(model_dict, root):
+    """Convert the keys of the model dict to parameters based starting at root."""
     return {os.path.join(root, "/".join(k)): v for k, v in utils.flatten(model_dict).items()}
 
 

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -72,9 +72,9 @@ def smudge(args):
     staged_file = file_io.load_staged_file(sys.stdin)
 
     model_dict = {}
-    for keys, param_dir in utils.walk_parameter_dir(
+    for keys, param_dir in utils.flatten(utils.walk_parameter_dir(
         os.path.abspath(staged_file["model_dir"])
-    ):
+    )):
         param_file = os.path.join(param_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
         model_dict[keys] = file_io.load_tracked_file(param_file)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -11,7 +11,7 @@ import logging
 import hashlib
 from collections import defaultdict, OrderedDict
 
-from git_theta import git_utils, checkpoints, params, file_io
+from git_theta import git_utils, checkpoints, params, file_io, utils
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -47,8 +47,13 @@ def clean(args):
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path)
 
     model_checkpoint = checkpoints.PyTorchCheckpoint.from_file(sys.stdin.buffer)
+    # TODO(bdlester): If we use Python3.7 as the minimum version, we don't need
+    # to use an OrderedDict as the standard dict retains the insertion order.
     staged_file_contents = OrderedDict({"model_dir": model_path})
-    for param, keys in checkpoints.iterate_dict_leaves(model_checkpoint):
+    # Sort the keys so we don't get changing diffs based on serialization order.
+    for keys, param in sorted(utils.flatten(model_checkpoint)):
+        # TODO(bdlester): We should update this staged_file_content from having
+        # different keys for shape, dtype, and hash to a dict.
         param_name = "/".join(keys)
         staged_file_contents[f"{param_name} shape"] = params.get_shape_str(param)
         staged_file_contents[f"{param_name} dtype"] = params.get_dtype_str(param)
@@ -66,17 +71,15 @@ def smudge(args):
     repo = git_utils.get_git_repo()
     staged_file = file_io.load_staged_file(sys.stdin)
 
-    model_dict = defaultdict(dict)
-    for leaf_dir, keys in checkpoints.iterate_dir_leaves(
-        os.path.abspath(staged_file["model_dir"])
+    model_dict = {}
+    for keys, param_dir in utils.walk_parameter_dir(
+        os.path.abspath(git_utils.get_git_cml_model_dir(repo, staged_file["model_dir"]))
     ):
-        param_file = os.path.join(leaf_dir, "params")
+        param_file = os.path.join(param_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
-        d = model_dict
-        for k in keys[:-1]:
-            d = d[k]
-        d[keys[-1]] = file_io.load_tracked_file(param_file)
+        model_dict[keys] = file_io.load_tracked_file(param_file)
 
+    model_dict = utils.unflatten(model_dict)
     model_checkpoint = checkpoints.PyTorchCheckpoint(model_dict)
     model_checkpoint.save(sys.stdout.buffer)
 

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -74,7 +74,7 @@ def smudge(args):
     model_dict = {}
     for keys, param_dir in utils.flatten(utils.walk_parameter_dir(
         os.path.abspath(staged_file["model_dir"])
-    )):
+    )).items():
         param_file = os.path.join(param_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
         model_dict[keys] = file_io.load_tracked_file(param_file)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -73,7 +73,7 @@ def smudge(args):
 
     model_dict = {}
     for keys, param_dir in utils.walk_parameter_dir(
-        os.path.abspath(git_utils.get_git_cml_model_dir(repo, staged_file["model_dir"]))
+        os.path.abspath(staged_file["model_dir"])
     ):
         param_file = os.path.join(param_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")

--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -5,10 +5,14 @@ import os
 import json
 import io
 
+<<<<<<< HEAD
 from file_or_name import file_or_name
+=======
+from . import utils
+>>>>>>> b367c80 (Add unittest to iterate_dir_leaves to help refactor)
 
 # Maintain access via checkpoints module for now.
-from .utils import iterate_dict_leaves
+from .utils import iterate_dict_leaves, iterate_dir_leaves
 
 
 class Checkpoint(dict):

--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -5,11 +5,9 @@ import os
 import json
 import io
 
-<<<<<<< HEAD
 from file_or_name import file_or_name
-=======
+
 from . import utils
->>>>>>> b367c80 (Add unittest to iterate_dir_leaves to help refactor)
 
 # Maintain access via checkpoints module for now.
 from .utils import iterate_dict_leaves, iterate_dir_leaves

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -101,3 +101,10 @@ def walk_dir(root, is_leaf=lambda x: "params" in os.listdir(x)):
         return dir_dict
 
     return _walk_dir((root,))
+
+
+def removed_params(new_model, old_model):
+    """Yield removed params, i.e. they are old_model but not new_model."""
+    new_model = flatten(new_model)
+    old_model = flatten(old_model)
+    yield from (old_model[k] for k in old_model.keys() - new_model.keys())

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -57,7 +57,8 @@ def iterate_dir_leaves(root):
         generates directory tree leaf, subdirectory list tuples
     """
     yield from map(
-        lambda kv: (kv[1], list(kv[0])), sorted(flatten(walk_dir(root)).items())
+        lambda kv: (kv[1], list(kv[0])),
+        sorted(flatten(walk_parameter_dir(root)).items()),
     )
 
 
@@ -87,7 +88,12 @@ def unflatten(d: Dict[Tuple[str], Any]) -> Dict[str, Union[Dict[str, Any], Any]]
     return nested
 
 
-def walk_dir(root, is_leaf=lambda x: "params" in os.listdir(x)):
+def walk_parameter_dir(root):
+    """Convert a directory structure into nested dicts use the presence of a params dict for leaf detection."""
+    return walk_dir(root, lambda path: "params" in os.listdir(path))
+
+
+def walk_dir(root, is_leaf):
     """Convert directory structure into nested dicts."""
 
     def _walk_dir(root):

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -34,3 +34,41 @@ def iterate_dict_leaves(d):
                 yield (v, prefix + [k])
 
     return _iterate_dict_leaves(d, [])
+
+
+def iterate_dir_leaves(root):
+    """
+    Generator that iterates through files in a directory tree and produces (path, dirs) tuples where
+    path is the file's path and dirs is the sequence of path components from root to the file.
+
+    Example
+    -------
+    root
+    ├── a
+    │   ├── c
+    │   └── d
+    └── b
+        └── e
+
+    iterate_dir_leaves(root) --> ((root/a/c, ['a','c']), (root/a/d, ['a','d']), (root/b/e, ['b','e']))
+
+    Parameters
+    ----------
+    root : str
+        Root of directory tree to iterate over
+
+    Returns
+    -------
+    generator
+        generates directory tree leaf, subdirectory list tuples
+    """
+
+    def _iterate_dir_leaves(root, prefix):
+        for d in os.listdir(root):
+            dir_member = os.path.join(root, d)
+            if not "params" in os.listdir(dir_member):
+                yield from _iterate_dir_leaves(dir_member, prefix=prefix + [d])
+            else:
+                yield (dir_member, prefix + [d])
+
+    return _iterate_dir_leaves(root, [])

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -114,6 +114,7 @@ def test_iterate_dict_leaves_are_sorted():
 
 
 def test_iterate_dir_leaves(tmp_path):
+    """Test the dir leaves happy path."""
     d = tmp_path / "a" / "d" / "params"
     d.mkdir(parents=True)
     c = tmp_path / "a" / "c" / "params"
@@ -132,6 +133,7 @@ def test_iterate_dir_leaves(tmp_path):
 
 
 def test_iterate_dir_leaves_empty_dir(tmp_path):
+    """Test that we don't include directory paths that don't end with "params"."""
     d = tmp_path / "a" / "d" / "params"
     d.mkdir(parents=True)
     c = tmp_path / "a" / "c" / "params"
@@ -154,7 +156,7 @@ def test_iterate_dir_leaves_empty_dir(tmp_path):
 
 
 def test_iterate_dir_leaves_params_and_dirs(tmp_path):
-    """Test that the presence of a `params` dir stops expanding dirs."""
+    """Test that the presence of a `params` dir stops expanding dirs, even if there are multiple subdirs."""
     d = tmp_path / "a" / "d" / "params"
     d.mkdir(parents=True)
     c = tmp_path / "a" / "c" / "params"
@@ -195,12 +197,16 @@ def test_iterate_dir_leaves_dirs_within_params(tmp_path):
 
 
 def test_remove_params():
+    """Test that removed values are actually detected and returned."""
     nested = make_nested_dict()
 
+    # Stochastically remove keys from the dict, but track what was removed.
     def _remove(curr, kept, removed):
         for k, v in curr.items():
             if random.random() > 0.33:
                 if isinstance(v, dict):
+                    # Recurse into a dict which will return both the kept and
+                    # removed values from that sub-dict.
                     keep, remove = _remove(v, {}, {})
                     kept[k] = keep
                     removed[k] = remove

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,6 +1,7 @@
 """Tests for utils.py"""
 
 import collections
+import os
 import operator as op
 import random
 import string
@@ -110,3 +111,84 @@ def test_iterate_dict_leaves_are_sorted():
     string_keys = ["/".join(k) for k in keys]
     sorted_string_keys = sorted(string_keys)
     assert string_keys == sorted_string_keys
+
+
+def test_iterate_dir_leaves(tmp_path):
+    d = tmp_path / "a" / "d" / "params"
+    d.mkdir(parents=True)
+    c = tmp_path / "a" / "c" / "params"
+    c.mkdir(parents=True)
+    e = tmp_path / "b" / "e" / "params"
+    e.mkdir(parents=True)
+
+    gold = [
+        (os.path.join(str(tmp_path), "a", "d"), ["a", "d"]),
+        (os.path.join(str(tmp_path), "a", "c"), ["a", "c"]),
+        (os.path.join(str(tmp_path), "b", "e"), ["b", "e"]),
+    ]
+
+    results = list(utils.iterate_dir_leaves(tmp_path))
+    assert sorted(results) == sorted(gold)
+
+
+def test_iterate_dir_leaves_empty_dir(tmp_path):
+    d = tmp_path / "a" / "d" / "params"
+    d.mkdir(parents=True)
+    c = tmp_path / "a" / "c" / "params"
+    c.mkdir(parents=True)
+    e = tmp_path / "b" / "e" / "params"
+    e.mkdir(parents=True)
+    empty = tmp_path / "b" / "f"
+    empty.mkdir(parents=True)
+    double_empty = tmp_path / "g" / "h"
+    double_empty.mkdir(parents=True)
+
+    gold = [
+        (os.path.join(str(tmp_path), "a", "d"), ["a", "d"]),
+        (os.path.join(str(tmp_path), "a", "c"), ["a", "c"]),
+        (os.path.join(str(tmp_path), "b", "e"), ["b", "e"]),
+    ]
+
+    results = list(utils.iterate_dir_leaves(tmp_path))
+    assert sorted(results) == sorted(gold)
+
+
+def test_iterate_dir_leaves_params_and_dirs(tmp_path):
+    """Test that the presence of a `params` dir stops expanding dirs."""
+    d = tmp_path / "a" / "d" / "params"
+    d.mkdir(parents=True)
+    c = tmp_path / "a" / "c" / "params"
+    c.mkdir(parents=True)
+    e = tmp_path / "b" / "e" / "params"
+    e.mkdir(parents=True)
+    f = tmp_path / "b" / "e" / "f" / "params"
+    f.mkdir(parents=True)
+
+    gold = [
+        (os.path.join(str(tmp_path), "a", "d"), ["a", "d"]),
+        (os.path.join(str(tmp_path), "a", "c"), ["a", "c"]),
+        (os.path.join(str(tmp_path), "b", "e"), ["b", "e"]),
+    ]
+    results = list(utils.iterate_dir_leaves(tmp_path))
+    assert sorted(results) == sorted(gold)
+
+
+def test_iterate_dir_leaves_dirs_within_params(tmp_path):
+    """Test that we don't go looking in the `params` even if there is another inside it."""
+    d = tmp_path / "a" / "d" / "params"
+    d.mkdir(parents=True)
+    c = tmp_path / "a" / "c" / "params"
+    c.mkdir(parents=True)
+    e = tmp_path / "b" / "e" / "params"
+    e.mkdir(parents=True)
+    f = tmp_path / "b" / "e" / "params" / "f" / "params"
+    f.mkdir(parents=True)
+
+    gold = [
+        (os.path.join(str(tmp_path), "a", "d"), ["a", "d"]),
+        (os.path.join(str(tmp_path), "a", "c"), ["a", "c"]),
+        (os.path.join(str(tmp_path), "b", "e"), ["b", "e"]),
+    ]
+    results = list(utils.iterate_dir_leaves(tmp_path))
+    print(results)
+    assert sorted(results) == sorted(gold)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -192,3 +192,26 @@ def test_iterate_dir_leaves_dirs_within_params(tmp_path):
     results = list(utils.iterate_dir_leaves(tmp_path))
     print(results)
     assert sorted(results) == sorted(gold)
+
+
+def test_remove_params():
+    nested = make_nested_dict()
+
+    def _remove(curr, kept, removed):
+        for k, v in curr.items():
+            if random.random() > 0.33:
+                if isinstance(v, dict):
+                    keep, remove = _remove(v, {}, {})
+                    kept[k] = keep
+                    removed[k] = remove
+                else:
+                    kept[k] = v
+            else:
+                removed[k] = v
+        return kept, removed
+
+    kept, gold_removed = _remove(nested, {}, {})
+    # Use Counters to check for bag equality.
+    gold_removed = collections.Counter(utils.flatten(gold_removed).values())
+    removed = collections.Counter(utils.removed_params(kept, nested))
+    assert removed == gold_removed


### PR DESCRIPTION
This PR updates the processing of model dictionaries and file system directories to use nested map flattening followed by things like set subtractions instead of using multiple similar iterate functions.

I implemented this by adding tests to the iteration functions we had been using. Updating the internal implementations of those iteration functions to use the new flat-map logic, ensured the tests still passed. Then I updated some of the places that used the `iterate_*` when it was simpler to use the map.

E2E testing by creating a simple pytorch model, commiting it, removing and updating parameters, committing that, and then adding parameters and commiting that.

Closes https://github.com/r-three/git-theta/issues/62