### PR TITLE
Fix location of the model dir in smudge

### DIFF
--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -68,7 +68,7 @@ def smudge(args):
 
     model_dict = defaultdict(dict)
     for leaf_dir, keys in checkpoints.iterate_dir_leaves(
-        os.path.abspath(staged_file["model_dir"])
+        os.path.abspath(git_utils.get_git_cml_model_dir(repo, staged_file["model_dir"]))
     ):
         param_file = os.path.join(leaf_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")


### PR DESCRIPTION
Currently the model_dir used during smudge is the relative path to the checkout from the repo root, not the converted on that lives in the .git_cml directory. This update changes it to the correct dir, this enables things like `git reset --hard` to update changes to a model and return to the last checked-in state, currently this results in a `FileNotFoundError: [Errno 2] No such file or directory: .../git-theta-test/my-model.pt` error as it tries to parse the directory structure from the actual model file.

I'm a little surprised that others haven't reported this error. When else in standard testing are we expecting smudge to get run?