### PR TITLE
Update line-based fileprocessing

### DIFF
--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -133,7 +133,7 @@ def read_gitattributes(gitattributes_file):
     """
     if os.path.exists(gitattributes_file):
         with open(gitattributes_file, "r") as f:
-            return f.readlines()
+            return [line.rstrip("\n") for line in f]
     else:
         return []
 
@@ -151,7 +151,9 @@ def write_gitattributes(gitattributes_file, attributes):
         Attributes to write to .gitattributes
     """
     with open(gitattributes_file, "w") as f:
-        f.writelines(attributes)
+        f.write("\n".join(attributes))
+        # End file with newline.
+        f.write("\n")
 
 
 def add_file(f, repo):
@@ -251,10 +253,10 @@ def add_filter_theta_to_gitattributes(gitattributes: List[str], path: str) -> st
             if fnmatch.fnmatchcase(path, match.group("pattern")):
                 pattern_found = True
                 if not "filter=theta" in match.group("attributes"):
-                    line = f"{line.rstrip()} filter=theta\n"
+                    line = f"{line.rstrip()} filter=theta"
         new_gitattributes.append(line)
     # If we don't find a matching pattern, add a new line that covers just this
     # specific file.
     if not pattern_found:
-        new_gitattributes.append(f"{path} filter=theta\n")
+        new_gitattributes.append(f"{path} filter=theta")
     return new_gitattributes

--- a/tests/git_utils_test.py
+++ b/tests/git_utils_test.py
@@ -1,50 +1,52 @@
 #!/usr/bin/env python3
 
+import os
+import pytest
+
 from git_theta import git_utils
 
 
 def test_add_filter_gitattributes_empty_file():
     assert git_utils.add_filter_theta_to_gitattributes([], "example") == [
-        "example filter=theta\n"
+        "example filter=theta"
     ]
 
 
 def test_add_filter_gitattributes_no_match():
     atts = [
-        "Some-other-path filter=lfs\n",
-        "*-cool-models.pt filter=theta\n",
+        "Some-other-path filter=lfs",
+        "*-cool-models.pt filter=theta",
     ]
     model_path = "path/to/my/model.pt"
     assert (
         git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"{model_path} filter=theta\n"
+        == f"{model_path} filter=theta"
     )
 
 
 def test_add_filter_gitattributes_exact_match():
     model_path = "really/cool/model/yall.ckpt"
-    atts = [f"{model_path} filter=lfs\n"]
+    atts = [f"{model_path} filter=lfs"]
     assert (
         git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"{model_path} filter=lfs filter=theta\n"
+        == f"{model_path} filter=lfs filter=theta"
     )
 
 
 def test_add_filter_gitattributes_pattern_match():
     model_path = "literal-the-best-checkpoint.pt"
-    atts = ["*.pt thing\n"]
+    atts = ["*.pt thing"]
     assert (
         git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"*.pt thing filter=theta\n"
+        == f"*.pt thing filter=theta"
     )
 
 
 def test_add_filter_gitattributes_multiple_matches():
     model_path = "100-on-mnist.npy"
-    atts = ["*.npy\n", f"{model_path}\n"]
+    atts = ["*.npy other-filter", f"{model_path} other-filter"]
     assert git_utils.add_filter_theta_to_gitattributes(atts, model_path) == [
-        "*.npy filter=theta\n",
-        f"{model_path} filter=theta\n",
+        f"{attr} filter=theta" for attr in atts
     ]
 
 
@@ -57,10 +59,10 @@ def test_add_filter_gitattributes_match_with_theta_already():
 def test_add_filter_gitattributes_rest_unchanged():
     model_path = "model-v3.pt"
     atts = [
-        "some-other-path filter=theta\n",
-        "really-reaaaally-big-files filter=lfs\n",
-        r"model-v\d.pt\n",
-        "another filter=theta\n",
+        "some-other-path filter=theta",
+        "really-reaaaally-big-files filter=lfs",
+        r"model-v\d.pt filter",
+        "another filter=theta",
     ]
     results = git_utils.add_filter_theta_to_gitattributes(atts, model_path)
     for i, (a, r) in enumerate(zip(atts, results)):
@@ -69,7 +71,94 @@ def test_add_filter_gitattributes_rest_unchanged():
         assert a == r
 
 
-def test_add_filter_gitattributes_all_newlines():
-    atts = [f"{x}\n" for x in list("abcdef")]
-    for gitattr in git_utils.add_filter_theta_to_gitattributes(atts, "b"):
-        assert gitattr.endswith("\n")
+@pytest.fixture
+def gitattributes():
+    return [
+        "*.pt filter=theta",
+        "*.png filter=lfs",
+        "really-big-file filter=lfs",
+        "something else, who knows how cool it could be",
+    ]
+
+
+def test_read_gitattributes(gitattributes, tmp_path):
+    """Test that reading gitattributes removes newlines."""
+    gitattributes_file = tmp_path / ".gitattributes"
+    with open(gitattributes_file, "w") as wf:
+        wf.write("\n".join(gitattributes))
+    read_attributes = git_utils.read_gitattributes(gitattributes_file)
+    for attr in read_attributes:
+        assert not attr.endswith("\n")
+
+
+def test_read_gitattributes_missing_file(tmp_path):
+    """Test that gitattributes file missing returns an empty list."""
+    missing_file = tmp_path / ".gitattributes"
+    assert not os.path.exists(missing_file)
+    read_attributes = git_utils.read_gitattributes(missing_file)
+    assert read_attributes == []
+
+
+def test_read_gitattributes_empty_file(tmp_path):
+    """Test that gitattributes file being empty returns an empty list."""
+    empty_file = tmp_path / ".gitattributes"
+    empty_file.touch()
+    assert os.path.exists(empty_file)
+    read_attributes = git_utils.read_gitattributes(empty_file)
+    assert read_attributes == []
+
+
+def test_write_gitattributes(gitattributes, tmp_path):
+    """Test that attributes are written to file unchanged and include newlines."""
+    attr_file = tmp_path / ".gitattributes"
+    for attr in gitattributes:
+        assert not attr.endswith("\n")
+    git_utils.write_gitattributes(attr_file, gitattributes)
+    with open(attr_file) as wf:
+        written_attrs = wf.readlines()
+    # Check for the newlines which I purposely left on with my reading code.
+    for written_attr, attr in zip(written_attrs, gitattributes):
+        assert written_attr == f"{attr}\n"
+
+
+def test_write_gitattributes_ends_in_newline(gitattributes, tmp_path):
+    """Make sure we have a final newline when writing out file."""
+    attr_file = tmp_path / ".gitattributes"
+    git_utils.write_gitattributes(attr_file, gitattributes)
+    with open(attr_file) as f:
+        attrs = f.read()
+    assert attrs[-1] == "\n"
+
+
+def test_write_gitattributes_creates_file(gitattributes, tmp_path):
+    """Make sure writing the git attributes can create the missing file before writing."""
+    attr_file = tmp_path / ".gitattributes"
+    assert not os.path.exists(attr_file)
+    git_utils.write_gitattributes(attr_file, gitattributes)
+    assert os.path.exists(attr_file)
+
+
+def test_read_write_gitattributes_write_read_round_trip(gitattributes, tmp_path):
+    """Test that we can write attributes, then read them back and they will match."""
+    attr_file = tmp_path / ".gitattributes"
+    git_utils.write_gitattributes(attr_file, gitattributes)
+    read_attrs = git_utils.read_gitattributes(attr_file)
+    assert read_attrs == gitattributes
+
+
+def test_read_write_gitattributes_read_write_round_trip(gitattributes, tmp_path):
+    """Test reading attrs from file, writing to new file and verify file contents match."""
+    attr_file = tmp_path / ".gitattributes"
+    with open(attr_file, "w") as wf:
+        wf.writelines([f"{attr}\n" for attr in gitattributes])
+
+    new_attr_file = tmp_path / ".gitattributes-2"
+    read_attrs = git_utils.read_gitattributes(attr_file)
+    git_utils.write_gitattributes(new_attr_file, read_attrs)
+
+    with open(attr_file) as old_f:
+        old_atts = old_f.read()
+    with open(new_attr_file) as new_f:
+        new_atts = new_f.read()
+
+    assert old_atts == new_atts


### PR DESCRIPTION
This PR updates the places where we do line-based file processing to remove newlines on read and add them on write. Having a consistent internal representation for file contents (`List[str]` without newlines) makes it easier to manipulate individual lines.

It also adds tests to the gitattributes reader and writer functions.