### PR TITLE
A sketch of plugins for checkpoint support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ result in all the hooks passing and the commit actually happening.
 
 ## Add support for new checkpoint types
 
-We support new plug ins via plug-ins. Third-party users do this by writing small installable
-packages that define and register a new checkpoint type.
+We support new checkpoint types via plug-ins. Third-party users do this by
+writing small installable packages that define and register a new checkpoint
+type.
 
 For first part development, instead of writing an external plugin, write the new checkpoint
 handler and add it to the `entry_points` dict of `setup.py`, you don't need to make your

--- a/README.md
+++ b/README.md
@@ -94,3 +94,12 @@ When black must reformat your file, it will show as the black pre-commit hook
 failing. When this happens you will see that the source file has been reformatted
 and is ready to be re-added to the index. Running `git commit` again should
 result in all the hooks passing and the commit actually happening.
+
+## Add support for new checkpoint types
+
+We support new plug ins via plug-ins. Third-party users do this by writing small installable
+packages that define and register a new checkpoint type.
+
+For first part development, instead of writing an external plugin, write the new checkpoint
+handler and add it to the `entry_points` dict of `setup.py`, you don't need to make your
+own package.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # git-theta
 
-A git extension for collaborative, continual, and communal development of machine learning models. 
+A git extension for collaborative, continual, and communal development of machine learning models.
 
 # How to use this repository?
-## Git LFS installation 
+## Git LFS installation
 Download and install Git LFS using the instructions from [the Git LFS website](https://git-lfs.github.com)
 
 ## Installing the git-theta package
-clone the repository  
+clone the repository
 ```bash
 git clone https://github.com/r-three/git-theta.git
 ```
@@ -22,7 +22,7 @@ Initialize git theta by running:
 git theta install
 ```
 
-The following lines will be added to `~.gitconfig` after successful installation. 
+The following lines will be added to `~.gitconfig` after successful installation.
 ```
 [filter "lfs"]
         smudge = git-lfs smudge -- %f
@@ -49,7 +49,7 @@ First, initialize your codebase as a git repository.
 git init
 ```
 In order to track the model checkpoint using git theta, run the command
-```bash 
+```bash
 git theta track model.pt
 ```
 
@@ -59,25 +59,25 @@ The above command adds the following lines to the `.gitattributes` files in the 
 model.pt filter=theta
 ```
 
-Stage the model in git by running the command 
+Stage the model in git by running the command
 ```bash
 git theta add model.pt
 ```
 
-This will store the parameters of the model using tensorstore inside a newly created `.git_theta/model.pt` directory. For example, consider a parameter name `decoder.block.0.layer.0.SelfAttention.k.weight` in the model checkpoint. The corresponding parameter values will be stored in `.git_theta/model.pt/decoder.block.0.layer.0.SelfAttention.k.weight`. 
+This will store the parameters of the model using tensorstore inside a newly created `.git_theta/model.pt` directory. For example, consider a parameter name `decoder.block.0.layer.0.SelfAttention.k.weight` in the model checkpoint. The corresponding parameter values will be stored in `.git_theta/model.pt/decoder.block.0.layer.0.SelfAttention.k.weight`.
 
 At this step, you can run `git status` and see all the `.git_theta/model.pt/{parameter_name}` files in "Changes to be committed" along with the model checkpoint file and the `.gitattributes` file.
 
-Since this is just a normal git repo, you can also add any other code/text files that you would like to version control using `git add`. You can then commit the changes and push to a git remote. 
+Since this is just a normal git repo, you can also add any other code/text files that you would like to version control using `git add`. You can then commit the changes and push to a git remote.
 
-The remote will contain the `.git_theta/model.pt` directory where the actual model parameters are stored. These parameteres are actually stored using Git LFS, and on certain git remotes (like Github and BitBucket) you should see them listed as LFS objects. The actual model checkpoint on the remove will simply contain some metadata related to the model parameters, such as the hash, shape and type of each of the parameter groups. 
+The remote will contain the `.git_theta/model.pt` directory where the actual model parameters are stored. These parameteres are actually stored using Git LFS, and on certain git remotes (like Github and BitBucket) you should see them listed as LFS objects. The actual model checkpoint on the remove will simply contain some metadata related to the model parameters, such as the hash, shape and type of each of the parameter groups.
 
 ## TBA
-`git diff` on the model checkpoint will identify which parameter groups are modified or added or removed. 
+`git diff` on the model checkpoint will identify which parameter groups are modified or added or removed.
 
 `git merge` will assume that all merges to the checkpoint (i.e. to parameter group files) result in merge conflicts and offer various possible automated merging strategies that can be tried and vetted.
 
-`git checkout` to a commit will construct a checkpoint based on the contents of `.git_theta/<model_checkpoint_name>` at that commit. 
+`git checkout` to a commit will construct a checkpoint based on the contents of `.git_theta/<model_checkpoint_name>` at that commit.
 
 # Development Setup
 
@@ -101,6 +101,6 @@ We support new checkpoint types via plug-ins. Third-party users do this by
 writing small installable packages that define and register a new checkpoint
 type.
 
-For first part development, instead of writing an external plugin, write the new checkpoint
-handler and add it to the `entry_points` dict of `setup.py`, you don't need to make your
-own package.
+Alternatively, plug-ins can be added directly to the `git-theta` package by
+adding the checkpoint handler to `checkpoints.py` and adding it to the
+`entry_points` dict of `setup.py`.

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -56,7 +56,7 @@ def add(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
-    checkpoint_type = args.type or checkpoints.sniff_checkpoint(args.file)
+    checkpoint_type = args.type or "pytorch"
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
     param_dict = checkpoint.from_file(args.file)
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -58,7 +58,7 @@ def add(args):
 
     checkpoint_type = args.type or checkpoints.sniff_checkpoint(args.file)
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
-    param_dict = checkpoint(args.file)
+    param_dict = checkpoint.from_file(args.file)
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -56,6 +56,7 @@ def add(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
+    # TODO: Don't default to pytorch once other checkpoint formats are supported.
     checkpoint_type = args.type or "pytorch"
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
     param_dict = checkpoint.from_file(args.file)

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -22,7 +22,7 @@ def parse_args():
         "add", help="add command used to stage a model file"
     )
     add_parser.add_argument("file", help="file being staged")
-    add_parser.add_argument("--type", help="The type of checkpoint we are adding.")
+    add_parser.add_argument("--type", help="The type of checkpoint being added.")
     add_parser.set_defaults(func=add)
 
     install_parser = subparsers.add_parser(

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -22,6 +22,7 @@ def parse_args():
         "add", help="add command used to stage a model file"
     )
     add_parser.add_argument("file", help="file being staged")
+    add_parser.add_argument("--type", help="The type of checkpoint we are adding.")
     add_parser.set_defaults(func=add)
 
     install_parser = subparsers.add_parser(
@@ -55,7 +56,9 @@ def add(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
-    param_dict = checkpoints.PyTorchCheckpoint.from_file(args.file)
+    checkpoint_type = args.type or checkpoints.sniff_checkpoint(args.file)
+    checkpoint = checkpoints.get_checkpoint(checkpoint_type)
+    param_dict = checkpoint(args.file)
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -48,6 +48,7 @@ def clean(args):
 
     # TODO(bdlester): Find a better way to include checkpoint type information
     # in git clean filters that are run without `git theta add`.
+    # TODO: Don't default to pytorch once other checkpoint formats are supported.
     checkpoint_type = os.environ.get("GIT_THETA_CHECKPOINT_TYPE") or "pytorch"
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
     model_checkpoint = checkpoint.from_file(sys.stdin.buffer)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -46,6 +46,7 @@ def clean(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path)
 
+    # TODO(bdlester): How do we know what kind of checkpoint it is here?
     model_checkpoint = checkpoints.PyTorchCheckpoint.from_file(sys.stdin.buffer)
     # TODO(bdlester): If we use Python3.7 as the minimum version, we don't need
     # to use an OrderedDict as the standard dict retains the insertion order.

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -46,8 +46,11 @@ def clean(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path)
 
-    # TODO(bdlester): How do we know what kind of checkpoint it is here?
-    model_checkpoint = checkpoints.PyTorchCheckpoint.from_file(sys.stdin.buffer)
+    # TODO(bdlester): Find a better way to include checkpoint type information
+    # in git clean filters that are run without `git theta add`.
+    checkpoint_type = os.environ.get("GIT_THETA_CHECKPOINT_TYPE") or "pytorch"
+    checkpoint = checkpoints.get_checkpoint(checkpoint_type)
+    model_checkpoint = checkpoint.from_file(sys.stdin.buffer)
     # TODO(bdlester): If we use Python3.7 as the minimum version, we don't need
     # to use an OrderedDict as the standard dict retains the insertion order.
     staged_file_contents = OrderedDict({"model_dir": model_path})

--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -138,6 +138,22 @@ def iterate_dir_leaves(root):
 
 
 def get_checkpoint(checkpoint_type: str) -> Checkpoint:
-    """Get a Checkpoint class based on name, including from a plugin."""
+    """Get a Checkpoint class by name.
+
+    The available checkpoint classes are enumerated in the `entry_points` field
+    of the package's setup.py. Additionally, user installed checkpoint plugins
+    are accessible via this function.
+
+    Parameters
+    ----------
+    checkpoint_type:
+        The name of the checkpoint type we want to use.
+
+    Returns
+    -------
+    Checkpoint
+        The checkpoint class. Returned class may be defined in a user installed
+        plugin.
+    """
     discovered_plugins = entry_points(group="git_theta.plugins.checkpoints")
     return discovered_plugins[checkpoint_type].load()

--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -60,8 +60,8 @@ class Checkpoint(dict):
         raise NotImplementedError
 
 
-class PyTorchCheckpoint(Checkpoint):
-    """Class for wrapping PyTorch checkpoints."""
+class PickledDictCheckpoint(Checkpoint):
+    """Class for wrapping picked dict checkpoints, commonly used with PyTorch."""
 
     @classmethod
     @file_or_name(checkpoint_path="rb")
@@ -135,14 +135,6 @@ def iterate_dir_leaves(root):
                 yield (dir_member, prefix + [d])
 
     return _iterate_dir_leaves(root, [])
-
-
-def sniff_checkpoint(checkpoint) -> str:
-    """Try to determine checkpoint format automagically."""
-    # TODO(bdlester): Expand checkpoint sniffing using things like magic numbers
-    # for binary formats and directory structure. Should we allow sniffers to
-    # be added as plugins?
-    return "pytorch"
 
 
 def get_checkpoint(checkpoint_type: str) -> Checkpoint:

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,18 +1,19 @@
-# Git Theta Plug-ins
+# git-theta Plug-ins
 
-Git theta support plugins for custom model checkpoint formats.
+git-theta support plugins for custom model checkpoint formats.
 
 ## Writing a Checkpoint Plug-in.
 
 A checkpoint plug-in should subclass `git_theta.checkpoints.Checkpoint`.  The plugin
-should implement the `_load` method which reads the checkpoint format into a dict
+should implement the `load` method which reads the checkpoint format into a dict
 mapping parameter names to parameter weights. It should also implement `save` which
 writes the original checkpoint format based on the dict of weights representation.
 
 ## Packaging a Plug-in
 
-The plug-in should be wrapped in an installable package that declares itself as a plugin with
-an entry point like this:
+The plug-in should be wrapped in an installable package that declares itself as a plugin using the
+`"git_theta.plugins.checkpoint"` entry point. The following should appear in the
+`setup.py` for the package.
 
 ```python
 setup(
@@ -30,8 +31,11 @@ setup(
 )
 ```
 
+Note: user plug-in packages can have any name as long as they register the
+`"git_theta.plugins.checkpoints"` entry point.
+
 ## Using a Plugin
 
-Having a plug-in installed will give `git_theta` access to the checkpoint class it provides. 
-To use this class include the CLI argument `--type my-cool-checkpoint` to the 
+Having a plug-in installed will give `git_theta` access to the checkpoint class it provides.
+To use this class include the CLI argument `--type my-cool-checkpoint` to the
 `git-theta add ...` command.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,37 @@
+# Git Theta Plug-ins
+
+Git theta support plugins for custom model checkpoint formats.
+
+## Writing a Checkpoint Plug-in.
+
+A checkpoint plug-in should subclass `git_theta.checkpoints.Checkpoint`.  The plugin
+should implement the `_load` method which reads the checkpoint format into a dict
+mapping parameter names to parameter weights. It should also implement `save` which
+writes the original checkpoint format based on the dict of weights representation.
+
+## Packaging a Plug-in
+
+The plug-in should be wrapped in an installable package that declares itself as a plugin with
+an entry point like this:
+
+```python
+setup(
+    ...,
+    install_requires=[
+        "git_theta",
+        ...,
+    ]
+    entry_points={
+        "git_theta.plugins.checkpoints": [
+            "my-cool-checkpoint = package.subpatch:MyCoolCheckpointClass",
+        ],
+    },
+    ...,
+)
+```
+
+## Using a Plugin
+
+Having a plug-in installed will give `git_theta` access to the checkpoint class it provides. 
+To use this class include the CLI argument `--type my-cool-checkpoint` to the 
+`git-theta add ...` command.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -2,8 +2,6 @@
 
 git-theta support plugins for custom model checkpoint formats.
 
-## Writing a Checkpoint Plug-in.
-
 A checkpoint plug-in should subclass `git_theta.checkpoints.Checkpoint`.  The plugin
 should implement the `load` method which reads the checkpoint format into a dict
 mapping parameter names to parameter weights. It should also implement `save` which
@@ -24,7 +22,7 @@ setup(
     ]
     entry_points={
         "git_theta.plugins.checkpoints": [
-            "my-cool-checkpoint = package.subpatch:MyCoolCheckpointClass",
+            "my-cool-checkpoint = package.module:MyCoolCheckpointClass",
         ],
     },
     ...,

--- a/plugins/json-checkpoint/README.md
+++ b/plugins/json-checkpoint/README.md
@@ -1,0 +1,4 @@
+# git-theta Plug-in Example
+
+This json based checkpoint is an example of using the plug-in system to create
+a new checkpoint type for git-theta.

--- a/plugins/json-checkpoint/git_theta_json_checkpoint/__init__.py
+++ b/plugins/json-checkpoint/git_theta_json_checkpoint/__init__.py
@@ -1,0 +1,1 @@
+"""A demo plugin for reading json checkpoints with git_theta."""

--- a/plugins/json-checkpoint/git_theta_json_checkpoint/checkpoints.py
+++ b/plugins/json-checkpoint/git_theta_json_checkpoint/checkpoints.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import io
+import json
+from git_theta import checkpoints
+
+
+class JSONCheckpoint(checkpoints.Checkpoint):
+    """Class for prototyping with JSON checkpoints"""
+
+    @classmethod
+    def load(cls, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to a checkpoint file
+
+        Returns
+        -------
+        model_dict : dict
+            Dictionary mapping parameter names to parameter values
+        """
+        if isinstance(checkpoint_path, io.IOBase):
+            return json.load(checkpoint_path)
+        else:
+            with open(checkpoint_path, "r") as f:
+                return json.load(f)
+
+    def save(self, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to write out the checkpoint file to
+        """
+        if isinstance(checkpoint_path, io.IOBase):
+            json.dump(self, checkpoint_path)
+        else:
+            with open(checkpoint_path, "w") as f:
+                json.dump(self, f)

--- a/plugins/json-checkpoint/setup.py
+++ b/plugins/json-checkpoint/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+
+
+setup(
+    name="git_theta_json_checkpoint",
+    description="Demo plugin for the git theta VCS.",
+    install_requires=[
+        "git_theta",
+    ],
+    packages=["git_theta_json_checkpoint"],
+    entry_points={
+        "git_theta.plugins.checkpoints": [
+            "json = git_theta_json_checkpoint.checkpoints:JSONCheckpoint",
+        ]
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
     },
     entry_points={
         "git_theta.plugins.checkpoints": [
-            "pytorch = git_theta.checkpoints:PyTorchCheckpoint"
+            "pytorch = git_theta.checkpoints:PickledDictCheckpoint",
+            "pickled-dict = git_theta.checkpoints:PickledDictCheckpoint",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,14 @@ setup(
         "torch",
         "tensorstore",
         "file-or-name",
+        "importlib_metadata",
     ],
     extras_require={
         "test": ["pytest"],
+    },
+    entry_points={
+        "git_theta.plugins.checkpoints": [
+            "pytorch = git_theta.checkpoints:PyTorchCheckpoint"
+        ]
     },
 )


### PR DESCRIPTION
This is a sketch of what a plug-in system would look like for user-defined checkpoint handlers.

It seems pretty low friction, especially because internally we only need to add new handler to the entry_points dict in setup.py, we don't need to create an installable package for each checkpoint type.

Also updates PyTorchCheckpoint to be a PickledDictCheckpoint, closes https://github.com/r-three/git-theta/issues/78