### PR TITLE
Draft: Feat/update plugins

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -7,9 +7,12 @@ import git
 import logging
 
 from git_theta import git_utils, checkpoints, file_io, utils
+from git_theta import updates
 
 logging.basicConfig(
-    level=logging.DEBUG, format="git-theta: [%(asctime)s] %(levelname)s - %(message)s"
+    level=logging.DEBUG,
+    filename="/tmp/git-theta.log",
+    format="git-theta: [%(asctime)s] %(levelname)s - %(message)s"
 )
 
 
@@ -22,7 +25,8 @@ def parse_args():
         "add", help="add command used to stage a model file"
     )
     add_parser.add_argument("file", help="file being staged")
-    add_parser.add_argument("--type", help="The type of checkpoint being added.")
+    add_parser.add_argument("--type", help="The type of checkpoint being added.", default="pytorch")
+    add_parser.add_argument("--update-type", help="The type of update being applied.", default="dense")
     add_parser.set_defaults(func=add)
 
     install_parser = subparsers.add_parser(
@@ -52,23 +56,32 @@ def add(args):
     """
     Splits model parameters file into parameter groups on filesystem and stages files
     """
+    logging.debug(f"Running git theta add on {args.file}")
+
     repo = git_utils.get_git_repo()
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
     # TODO: Don't default to pytorch once other checkpoint formats are supported.
-    checkpoint_type = args.type or "pytorch"
-    checkpoint = checkpoints.get_checkpoint(checkpoint_type)
+    checkpoint = checkpoints.get_checkpoint(args.checkpoint_type)
+    logging.debug("Using checkpoint type={args.checkpoint_type}")
     param_dict = checkpoint.from_file(args.file)
+    update = updates.get_update(args.update_type)()
+    logging.debug("Using update type={args.update_type}")
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)
-        file_io.write_tracked_file(param_file, param)
+        # file_io.write_tracked_file(param_file, param)
+        update.write(param_file, param)
         git_utils.add_file(param_file, repo)
 
     for param_file in utils.removed_params(param_dict, utils.walk_parameter_dir(theta_model_dir)):
         git_utils.remove_file(param_file, repo)
 
+    repo.git.update_environment(
+        GIT_THETA_CHECKPOINT_TYPE=args.checkpoint_type,
+        GIT_THETA_UPDATE_TYPE=args.update_type
+    )
     git_utils.add_file(model_path, repo)
 
 

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -11,7 +11,6 @@ from git_theta import updates
 
 logging.basicConfig(
     level=logging.DEBUG,
-    filename="/tmp/git-theta.log",
     format="git-theta: [%(asctime)s] %(levelname)s - %(message)s"
 )
 
@@ -25,7 +24,7 @@ def parse_args():
         "add", help="add command used to stage a model file"
     )
     add_parser.add_argument("file", help="file being staged")
-    add_parser.add_argument("--type", help="The type of checkpoint being added.", default="pytorch")
+    add_parser.add_argument("--checkpoint-type", help="The type of checkpoint being added.", default="pytorch")
     add_parser.add_argument("--update-type", help="The type of update being applied.", default="dense")
     add_parser.set_defaults(func=add)
 
@@ -64,10 +63,10 @@ def add(args):
 
     # TODO: Don't default to pytorch once other checkpoint formats are supported.
     checkpoint = checkpoints.get_checkpoint(args.checkpoint_type)
-    logging.debug("Using checkpoint type={args.checkpoint_type}")
+    logging.debug(f"Using checkpoint type={args.checkpoint_type}")
     param_dict = checkpoint.from_file(args.file)
     update = updates.get_update(args.update_type)()
-    logging.debug("Using update type={args.update_type}")
+    logging.debug(f"Using update type={args.update_type}")
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -87,13 +87,13 @@ def smudge(args):
         # TODO load tracked file from git
         param_file = os.path.join(param_dir, "params")
         update_type = json.loads(git_utils.load_tracked_file_from_git(
-            os.path.join(param_file, "metadata"), str(repo.commit())))["update"]
+            os.path.join(param_file, "metadata")))["update"]
         logging.debug(f"smudge-filter: Loading parameter '{param_dir}' with a '{update_type}' update")
         update = updates.get_update(update_type)()
             # staged_file["model_dir"],
             # os.path.abspath(git_utils.get_git_theta_model_dir(repo, staged_file["model_dir"])))
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
-        model_dict[keys] = update.apply(param_file, str(repo.commit()))
+        model_dict[keys] = update.apply(param_file)
 
     model_dict = utils.unflatten(model_dict)
     logging.debug(model_dict)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -12,9 +12,11 @@ import hashlib
 from collections import defaultdict, OrderedDict
 
 from git_theta import git_utils, checkpoints, params, file_io, utils
+from git_theta import updates
 
 logging.basicConfig(
     level=logging.DEBUG,
+    filename="/tmp/git-theta.log",
     format="git-theta-filter: [%(asctime)s] %(levelname)s - %(message)s",
 )
 
@@ -50,7 +52,9 @@ def clean(args):
     # in git clean filters that are run without `git theta add`.
     # TODO: Don't default to pytorch once other checkpoint formats are supported.
     checkpoint_type = os.environ.get("GIT_THETA_CHECKPOINT_TYPE") or "pytorch"
+    logging.debug(f"clean-filter: using {checkpoint_type=}")
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
+
     model_checkpoint = checkpoint.from_file(sys.stdin.buffer)
     # TODO(bdlester): If we use Python3.7 as the minimum version, we don't need
     # to use an OrderedDict as the standard dict retains the insertion order.
@@ -78,14 +82,24 @@ def smudge(args):
 
     model_dict = {}
     for keys, param_dir in utils.flatten(utils.walk_parameter_dir(
-        os.path.abspath(staged_file["model_dir"])
+        os.path.abspath(git_utils.get_git_theta_model_dir(repo, staged_file["model_dir"]))
     )).items():
+        # TODO load tracked file from git
         param_file = os.path.join(param_dir, "params")
+        update_type = json.loads(git_utils.load_tracked_file_from_git(
+            os.path.join(param_file, "metadata"), str(repo.commit())))["update"]
+        logging.debug(f"smudge-filter: Loading parameter '{param_dir}' with a '{update_type}' update")
+        update = updates.get_update(update_type)()
+            # staged_file["model_dir"],
+            # os.path.abspath(git_utils.get_git_theta_model_dir(repo, staged_file["model_dir"])))
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
-        model_dict[keys] = file_io.load_tracked_file(param_file)
+        model_dict[keys] = update.apply(param_file, str(repo.commit()))
 
     model_dict = utils.unflatten(model_dict)
-    model_checkpoint = checkpoints.PyTorchCheckpoint(model_dict)
+    logging.debug(model_dict)
+    checkpoint_type = os.environ.get("GIT_THETA_CHECKPOINT_TYPE") or "pytorch"
+    model_checkpoint = checkpoints.get_checkpoint(checkpoint_type)(model_dict)
+    logging.debug(f"clean-filter: using {checkpoint_type=}")
     model_checkpoint.save(sys.stdout.buffer)
 
 

--- a/git_theta/file_io.py
+++ b/git_theta/file_io.py
@@ -6,6 +6,16 @@ import logging
 from file_or_name import file_or_name
 
 
+def read_tensorstore_from_memory(files):
+    ctx = ts.Context()
+    kvs = ts.KvStore.open("memory://", context=ctx).result()
+    for name, contents in files.items():
+        kvs[name] = contents
+
+    store = ts.open({"driver": "zarr", "kvstore": "memory://"}, context=ctx).result()
+    return store.read().result()
+
+
 def load_tracked_file(f):
     """
     Load tracked file

--- a/git_theta/updates/__init__.py
+++ b/git_theta/updates/__init__.py
@@ -1,0 +1,3 @@
+"""Classes for controlling how parameter updates are made."""
+
+from git_theta.updates.base import Update, get_update

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -1,0 +1,48 @@
+"""Base class for parameter update plugins."""
+
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+from typing import Optional
+
+
+class Update:
+    """Base class for parameter update plugins."""
+
+    # def __init__(self, checkpoint_path, git_theta_model_dir):
+    #     self.checkpoint_path = checkpoint_path
+    #     self.git_theta_model_dir = git_theta_model_dir
+    @property
+    def name(self):
+        raise NotImplementedError
+
+    def read(self, path, commit: Optional[str] = None):
+        raise NotImplementedError
+
+    def write(self, path, parameter):
+        raise NotImplementedError
+
+    def apply(self, path, commit: Optional[str] = None):
+        raise NotImplementedError
+
+
+def get_update(update_type: str) -> Update:
+    """Get an Update class by name.
+
+    Parameters
+    ----------
+    update_type:
+        The name of the update type we want to use.
+
+    Returns
+    -------
+    Update
+        The update class. Returned class may be defined in a user installed
+        plugin.
+    """
+    discovered_plugins = entry_points(group="git_theta.plugins.updates")
+    return discovered_plugins[update_type].load()

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+from typing import Optional
+from git_theta.updates import Update
+from git_theta import file_io
+from git_theta import git_utils
+
+
+class DenseUpdate(Update):
+    """An update where all parameters are changed."""
+
+    @property
+    def name(self):
+        return "dense"
+
+    def read(self, path, commit: Optional[str] = None):
+        if commit is None or commit == "HEAD":
+            return file_io.load_tracked_file(path)
+        return file_io.read_tensorstore_from_memory(
+            git_utils.load_tracked_dir_from_git(path, commit, apply_filters=True)
+        )
+
+    def write(self, path, parameter):
+        file_io.write_tracked_file(path, parameter)
+        file_io.write_staged_file(os.path.join(path, "metadata"), {"update": self.name})
+
+    def apply(self, path, commit: Optional[str] = None):
+        logging.debug(f"Reading Dense update to {path}@{commit=}")
+        return self.read(path, commit)

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+from typing import Optional
+from git_theta.updates import Update, get_update
+from git_theta import file_io
+from git_theta import git_utils
+
+
+class SparseUpdate(Update):
+    """An update where only some parameters are touched."""
+
+    @property
+    def name(self):
+        return "sparse"
+
+    def read(self, path, commit: Optional[str] = None):
+        # TODO: Update to sparse special reads
+        if commit is None or commit == "HEAD":
+            return file_io.load_tracked_file(path)
+        return file_io.read_tensorstore_from_memory(
+            git_utils.load_tracked_dir_from_git(path, commit, apply_filters=True)
+        )
+
+    def calculate_sparse_update(self, new_value, prev_value):
+        # TODO: Update to calculate a real sparse value
+        return new_value - prev_value
+
+    def write(self, path, parameter):
+        logging.debug(f"Writing sparse update to '{path}'")
+        prev_commit = git_utils.get_previous_commit(path)
+        logging.debug(f"The last time '{path}' was updated was commit={prev_commit}")
+        prev_metadata = json.loads(
+            git_utils.load_tracked_file_from_git(
+                os.path.join(path, "metadata"), prev_commit
+            )
+        )
+        prev_update_type = prev_metadata["update"]
+        logging.debug(f"The last update to '{path}' was a {prev_update_type} update.")
+        prev_update = get_update(prev_update_type)()
+        prev_value = prev_update.apply(path, prev_commit)
+        logging.debug(f"Calculating sparse difference.")
+        difference = self.calculate_sparse_update(parameter, prev_value)
+        logging.debug(f"Writing sparse difference to '{path}'")
+        file_io.write_tracked_file(path, difference)
+        file_io.write_staged_file(os.path.join(path, "metadata"), {"update": self.name})
+
+    def apply(self, path, commit: Optional[str] = None):
+        logging.debug(f"Calculating result of sparse update to '{path}' at {commit=}")
+        sparse_update = self.read(path, commit)
+        prev_commit = git_utils.get_previous_commit(path, commit)
+        logging.debug(f"The last time '{path}' was updated was commit={prev_commit}")
+        prev_metadata = json.loads(
+            git_utils.load_tracked_file_from_git(
+                os.path.join(path, "metadata"), prev_commit
+            )
+        )
+        prev_update_type = prev_metadata["update"]
+        logging.debug(f"The last update to '{path}' was a {prev_update_type} update.")
+        prev_update = get_update(prev_update_type)()
+        logging.debug(f"Recursively getting the previous value.")
+        prev_value = prev_update.apply(path, prev_commit)
+        return sparse_update + prev_value

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -49,6 +49,11 @@ class SparseUpdate(Update):
 
     def apply(self, path, commit: Optional[str] = None):
         logging.debug(f"Calculating result of sparse update to '{path}' at {commit=}")
+        if commit is None or commit == "HEAD":
+            commit = git_utils.get_previous_commit(path, commit)
+            logging.debug(
+                f"File state at HEAD requested, translating to real {commit=}"
+            )
         sparse_update = self.read(path, commit)
         prev_commit = git_utils.get_previous_commit(path, commit)
         logging.debug(f"The last time '{path}' was updated was commit={prev_commit}")

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ setup(
         "git_theta.plugins.checkpoints": [
             "pytorch = git_theta.checkpoints:PickledDictCheckpoint",
             "pickled-dict = git_theta.checkpoints:PickledDictCheckpoint",
-        ]
+        ],
+        "git_theta.plugins.updates": [
+            "dense = git_theta.updates.dense:DenseUpdate",
+            "sparse = git_theta.updates.sparse:SparseUpdate",
+        ],
     },
 )


### PR DESCRIPTION
This PR is a draft of two things, first of using plugins for update types, the second is for using git to store and fetch updates that are based on deltas from previous values.

Points of Interest:
1) Parameter metadata is in a new `metadata` file for the parameter _within_ the parameter directory. This was critical for the model checkpoint clean filter running in contexts like `git status`
2) The smudge filter isn't perfect for time-travel. When `git checkout ${COMMIT}` happens the version of the cleaned model checkpoint from that commit is passed via CLI, but the parameter values start with the ones on disk. For the disk only solution this is ok (as long as the parameters were checked out before the checked-in model checkpoint is smudged, which currently happens because `.git_theta` sorts first). For this solution you end up with a wrong checkpoint where the parameters are from the commit you are leaving instead of the commit you are entering. This can be fixed by running `git reset --hard` after the checkout happens. But any thoughts on how to fix this would be great. 
3) I converted some of the logging to file, because logging in `git-theta-filter` doesn't get shown on the screen. We should revert this or make logging more robust before merging.
4) "Sparse" updates are very simplistic right now, they are stored as dense offsets just to get it done, not something smart like a CSR matrix.
5) If we don't go with the git method, we can at least use the update plugins for a disk-based setting. Similarly, ideas like the recursive update can still be used with on disk updates.

Depends on https://github.com/r-three/git-theta/pull/74, once that is merged the changes here will be easier to see.