### PR TITLE
store path to model directory under .git_theta/ in metadata file

### DIFF
--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -44,7 +44,7 @@ def clean(args):
 
     repo = git_utils.get_git_repo()
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
-    theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path)
+    theta_model_dir = git_utils.get_relative_path_from_root(repo, git_utils.get_git_theta_model_dir(repo, model_path))
 
     # TODO(bdlester): Find a better way to include checkpoint type information
     # in git clean filters that are run without `git theta add`.
@@ -54,7 +54,7 @@ def clean(args):
     model_checkpoint = checkpoint.from_file(sys.stdin.buffer)
     # TODO(bdlester): If we use Python3.7 as the minimum version, we don't need
     # to use an OrderedDict as the standard dict retains the insertion order.
-    staged_file_contents = OrderedDict({"model_dir": model_path})
+    staged_file_contents = OrderedDict({"model_dir": theta_model_dir})
     # Sort the keys so we don't get changing diffs based on serialization order.
     for keys, param in sorted(utils.flatten(model_checkpoint).items()):
         # TODO(bdlester): We should update this staged_file_content from having
@@ -85,7 +85,7 @@ def smudge(args):
         model_dict[keys] = file_io.load_tracked_file(param_file)
 
     model_dict = utils.unflatten(model_dict)
-    model_checkpoint = checkpoints.PyTorchCheckpoint(model_dict)
+    model_checkpoint = checkpoints.PytorchCheckpoint(model_dict)
     model_checkpoint.save(sys.stdout.buffer)
 
 

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -85,7 +85,7 @@ def smudge(args):
         model_dict[keys] = file_io.load_tracked_file(param_file)
 
     model_dict = utils.unflatten(model_dict)
-    model_checkpoint = checkpoints.PytorchCheckpoint(model_dict)
+    model_checkpoint = checkpoints.PyTorchCheckpoint(model_dict)
     model_checkpoint.save(sys.stdout.buffer)
 
 


### PR DESCRIPTION
Fix bug where the clean filter puts the path to the checkpoint in the metadata file, but the smudge filter expects the path to the `.git_theta/` checkpoint directory. 