### PR TITLE
Add support for multiple update types via plugins

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -6,7 +6,7 @@ import sys
 import git
 import logging
 
-from git_theta import git_utils, checkpoints, file_io, utils
+from git_theta import git_utils, checkpoints, file_io, utils, updates
 
 logging.basicConfig(
     level=logging.DEBUG, format="git-theta: [%(asctime)s] %(levelname)s - %(message)s"
@@ -22,7 +22,10 @@ def parse_args():
         "add", help="add command used to stage a model file"
     )
     add_parser.add_argument("file", help="file being staged")
-    add_parser.add_argument("--type", help="The type of checkpoint being added.")
+    add_parser.add_argument(
+        "--checkpoint-type", help="The type of checkpoint being added."
+    )
+    add_parser.add_argument("--update-type", help="The type of update being used.")
     add_parser.set_defaults(func=add)
 
     install_parser = subparsers.add_parser(
@@ -57,14 +60,22 @@ def add(args):
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
     theta_model_dir = git_utils.get_git_theta_model_dir(repo, model_path, create=True)
 
-    checkpoint_handler = checkpoints.get_checkpoint_handler(args.type)
-    logging.debug(f"git theta add using checkpoint type={checkpoint_handler.name}")
+    checkpoint_handler = checkpoints.get_checkpoint_handler(args.checkpoint_type)
     param_dict = checkpoint_handler.from_file(args.file)
+    logging.debug(f"git theta add using checkpoint type={param_dict.name}")
 
+    update = updates.get_update_handler(args.update_type)()
+    logging.debug(f"Using update type={update.name}")
+
+    # Iterate through the parameters in the /new/ checkpoint (after some training).
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)
-        file_io.write_tracked_file(param_file, param)
+        # Use the update plugins to add write this new parameter value. The plugin
+        # used controls if it is dense or sparse, if the whole param is written/partial, etc.
+        update.write(param_file, param)
+        # Call add on the .../params dir so that when many files are made under
+        # it they are all added.
         git_utils.add_file(param_file, repo)
 
     for param_file in utils.removed_params(
@@ -72,6 +83,12 @@ def add(args):
     ):
         git_utils.remove_file(param_file, repo)
 
+    repo.git.update_environment(
+        **{
+            utils.EnvVarConstants.CHECKPOINT_TYPE: param_dict.name,
+            utils.EnvVarConstants.UPDATE_TYPE: update.name,
+        }
+    )
     git_utils.add_file(model_path, repo)
 
 

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -11,10 +11,12 @@ import logging
 import hashlib
 from collections import defaultdict, OrderedDict
 
-from git_theta import git_utils, checkpoints, params, file_io, utils
+from git_theta import git_utils, checkpoints, params, file_io, utils, updates
 
 logging.basicConfig(
     level=logging.DEBUG,
+    # Log to a file for clean/smudge as they don't appear on the console when called via git.
+    filename="/tmp/git-theta.log",
     format="git-theta-filter: [%(asctime)s] %(levelname)s - %(message)s",
 )
 
@@ -99,13 +101,30 @@ def smudge(args):
     for keys, param_dir in utils.flatten(
         utils.walk_parameter_dir(os.path.abspath(staged_file["model_dir"]))
     ).items():
+        parameter_name = ".".join(keys)
+        logging.debug(f"Populating model parameter {parameter_name}")
         param_file = os.path.join(param_dir, "params")
-        logging.debug(f"Populating model parameter {'/'.join(keys)}")
-        model_dict[keys] = file_io.load_tracked_file(param_file)
+
+        # Look up the most recent update applied to the parameter in the
+        # .../params/metadata file.
+        update_location = updates.most_recent_update(param_file)
+        logging.debug(f"{parameter_name} as lasted updated with {update_location}.")
+        # Look up what type of update this most recent one is using the
+        # .../params/updates/${hash}/metadata file.
+        update_type = updates.read_update_type(update_location)
+        logging.debug(f"{parameter_name}'s last update was a {update_type} update.")
+        # Get the update type from the plugin registry.
+        update = updates.get_update_handler(update_type)()
+        # Apply the most recent update (which may get previous values recursively)
+        # to get the current value of the parameter.
+        model_dict[keys] = update.apply(update_location)
 
     model_dict = utils.unflatten(model_dict)
     checkpoint_handler = checkpoints.get_checkpoint_handler()
     model_checkpoint = checkpoint_handler(model_dict)
+    logging.debug(
+        f"git theta smudge filter: Using checkpoint type = {model_checkpoint.name}"
+    )
     model_checkpoint.save(sys.stdout.buffer)
 
 

--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -102,6 +102,24 @@ def get_relative_path_from_root(repo, path):
     return relative_path
 
 
+def get_absolute_path(repo: git.Repo, relative_path: str) -> str:
+    """Get the absolute path of a repo relative path.
+
+    Parameters
+    ----------
+    repo
+        Repo object for the current git repository.
+    path
+        The relative path to a file from the root of the git repo.
+
+    Returns
+    -------
+    str
+        The absolute path to the file.
+    """
+    return os.path.abspath(os.path.join(repo.working_dir, relative_path))
+
+
 def get_gitattributes_file(repo):
     """
     Get path to this repo's .gitattributes file

--- a/git_theta/updates/__init__.py
+++ b/git_theta/updates/__init__.py
@@ -1,0 +1,9 @@
+"""Classes for controlling how parameter updates are made."""
+
+from git_theta.updates.base import (
+    Update,
+    get_update_handler,
+    UpdateConstants,
+    most_recent_update,
+    read_update_type,
+)

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -1,0 +1,237 @@
+"""Base class for parameter update plugins.
+
+Example directory structure of how updates are stored.
+
+.git_theta/my-model.pt/
+├── layers.0.bias
+│   └── params
+│       ├── metadata  # Pointer to the most recent update.
+│       └── updates
+│           │   # This is the hash of the parameter after the update, not the contents of the update.
+│           ├── 13f81e06d1a47a437541a26f86fd20c89ccf73ea
+│           │   ├── 0
+│           │   └── metadata  # Update type and pointer to the last update.
+│           ├── 1f40b7caef2f961b4bde95f9a450c3a12eb6f249
+│           │   ├── 0
+│           │   └── metadata
+│           └── 77db6ed78df01aecbb9e7990a87d50f7dc2d5579
+│               ├── 0
+│               └── metadata
+├── ...
+└── layers.1.weight
+    └── params
+        ├── metadata
+        └── updates
+            ├── 2ceb7dac4dd0b012fd404e227c13cf66bd25cf3a
+            │   ├── 0.0
+            │   └── metadata
+            ├── aeefd921f332f102e3e77ca6ec3d46d707afe9a9
+            │   ├── 0.0
+            │   └── metadata
+            └── b16693be23b9146457c20752cdac2796de5a7290
+                ├── 0.0
+                └── metadata
+
+
+Example .../layers.0.bias/params/metadata
+[
+    ".git_theta/my-model.pt/layers.0.bias/params/updates/77db6ed78df01aecbb9e7990a87d50f7dc2d5579"
+]
+
+Example .../params/updates/${hash}/metadata
+{
+    "update": "sparse",
+    "previous": ".git_theta/my-model.pt/layers.0.bias/params/updates/13f81e06d1a47a437541a26f86fd20c89ccf73ea"
+}
+
+Another Example
+{
+    "update": "dense"
+}
+
+"""
+
+import logging
+import os
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+from typing import Optional
+
+import numpy as np
+from git_theta import file_io
+from git_theta import git_utils
+from git_theta import utils
+
+
+class UpdateConstants:
+    """Scoped constants for consistent file name and key naming."""
+
+    UPDATE_KEY: str = "update"
+    UPDATES_DIR: str = "updates"
+    METADATA_FILE: str = "metadata"
+    PREVIOUS_KEY: str = "previous"
+
+
+class Update:
+    """Base class for parameter update plugins."""
+
+    @property
+    def name(self):
+        """The name used to get this class as a plugin."""
+        raise NotImplementedError
+
+    def read(self, path: str) -> np.ndarray:
+        """Read the parameter values in the path dir.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path that contains parameter
+            update values.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter values at path.
+        """
+        raise NotImplementedError
+
+    def write(self, path: str, parameter: np.ndarray):
+        """Write `parameter` values to path.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to write to.
+        parameter
+            The values to write.
+        """
+        raise NotImplementedError
+
+    def apply(self, path: str) -> np.ndarray:
+        """Get the update parameter values after applying the update from `path`.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to the update we want
+            the result from.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter after the update at `path` is applied.
+        """
+        raise NotImplementedError
+
+    def record_update(self, path: str, update_path: str):
+        """Update the most recent update metadata file to point to this update.
+
+        Parameters
+        ----------
+        path
+            The path to the .../params dir for a parameter, this should be absolute.
+        update_path
+            The path to the .../params/updates/${hash} dir for a parameter, can
+            be absolute or relative.
+        """
+        metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
+        if not os.path.exists(metadata_file):
+            metadata = []
+        else:
+            metadata = file_io.load_staged_file(metadata_file)
+        update_path = git_utils.get_relative_path_from_root(
+            git_utils.get_git_repo(), update_path
+        )
+        logging.debug(
+            f"Recording recent update as '{update_path}' was '{metadata[-1] if metadata else None}'"
+        )
+        file_io.write_staged_file(metadata_file, [update_path])
+
+
+def most_recent_update(path: str) -> str:
+    """Get the most recent update applied to the parameter.
+
+    Note:
+        Path is expected to be a path to the params directory of a parameter.
+        It should be an absolute path.
+
+    Parameters
+    ----------
+    path
+        The path to the .../params dir for a parameter.
+
+    Returns
+    -------
+    str
+        The path to the previous update for the parameter, relative to the repo root.
+    """
+    metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
+    metadata = file_io.load_staged_file(metadata_file)
+    return metadata[0] if metadata else None
+
+
+def read_update_type(path: str) -> str:
+    """Get the update type used for some update.
+
+    Notes:
+        Path is expected to be a .../params/updates/${hash} path for a parameter.
+        It should be an absolute path.
+
+    Parameters
+    ----------
+    path
+        The path to the .../params/updates/${hash} path for a parameter.
+
+    Returns
+    -------
+    str
+        The update type used to save this update.
+    """
+    metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
+    metadata = file_io.load_staged_file(metadata_file)
+    return metadata[UpdateConstants.UPDATE_KEY]
+
+
+def get_update_handler_name(update_type: Optional[str] = None) -> str:
+    """Get the update type based on multiple overrides.
+
+    The order of precedence is:
+    1) User input via the update_type parameter
+    2) The GIT_THETA_UPDATE_TYPE environment variable
+    3) The default value ("dense")
+
+    Parameters
+    ----------
+    update_type
+        The update type name
+
+    Returns
+    -------
+    str
+        The update type based on overrides.
+    """
+    return update_type or os.environ.get(utils.EnvVarConstants.UPDATE_TYPE) or "dense"
+
+
+def get_update_handler(update_type: Optional[str] = None) -> Update:
+    """Get an Update class by name.
+
+    Parameters
+    ----------
+    update_type
+        The name of the update type we want to use.
+
+    Returns
+    -------
+    Update
+        The update class. Returned class my be defined in a user installed plugin.
+    """
+    update_type = get_update_handler_name(update_type)
+    discovered_plugins = entry_points(group="git_theta.plugins.updates")
+    return discovered_plugins[update_type].load()

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -56,6 +56,8 @@ class DenseUpdate(Update):
             The values to write.
         """
         # Remove any past updates to begin anew.
+        # TODO: Move to using git_utils.remove_file once the edge case of the
+        # path not existing is git is resolved.
         shutil.rmtree(path)
         parameter_hash = params.get_hash(parameter)
         output_dir = os.path.join(path, UpdateConstants.UPDATES_DIR, parameter_hash)

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -1,0 +1,92 @@
+"""Class managing dense parameter updates."""
+
+import logging
+import os
+import shutil
+from typing import Optional
+import numpy as np
+from git_theta import file_io
+from git_theta import params
+from git_theta.updates import Update, UpdateConstants
+
+
+class DenseUpdate(Update):
+    """An update where all parameters are changed."""
+
+    @property
+    def name(self):
+        """The name used to get this class as a plugin."""
+        return "dense"
+
+    def read(self, path: str) -> np.ndarray:
+        """Read the parameter values in the path dir.
+
+        Note:
+            In this case, the read parameter values are the whole update, all
+            values are overwritten so the result of this read will just be
+            returned.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path that contains parameter
+            update values.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter values at path.
+        """
+        logging.debug(f"Reading Dense Update from '{path}'.")
+        return file_io.load_tracked_file(path)
+
+    def write(self, path: str, parameter: np.ndarray):
+        """Write `parameter` values to path.
+
+        Note:
+            This update type removes all the previous updates in the .../updates/
+            directory as they are no longer needed. This update sets all parameter
+            values.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to write to.
+        parameter
+            The values to write.
+        """
+        # Remove any past updates to begin anew.
+        shutil.rmtree(path)
+        parameter_hash = params.get_hash(parameter)
+        output_dir = os.path.join(path, UpdateConstants.UPDATES_DIR, parameter_hash)
+        logging.debug(f"Writing Dense Update to '{output_dir}'")
+        # Write all parameter values as is to the update directory.
+        file_io.write_tracked_file(output_dir, parameter)
+        # Record update type information in the update metadata file.
+        file_io.write_staged_file(
+            os.path.join(output_dir, UpdateConstants.METADATA_FILE),
+            {UpdateConstants.UPDATE_KEY: self.name},
+        )
+        # Update the parameter metadata file setting this update as the most recent one.
+        self.record_update(path, output_dir)
+
+    def apply(self, path: str) -> np.ndarray:
+        """Get the update parameter values after applying the update from `path`.
+
+        Note:
+            As this update touches all parameters, the application of this update
+            is just the values read from disk.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to the update we want
+            the result from.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter after the update at `path` is applied.
+        """
+        logging.debug(f"Applying Dense Update to '{path}'")
+        return self.read(path)

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -1,0 +1,164 @@
+"""A class for handling sparse updates to parameters."""
+
+import json
+import logging
+import os
+from typing import Optional
+import numpy as np
+from git_theta.updates import (
+    Update,
+    UpdateConstants,
+    get_update_handler,
+    most_recent_update,
+    read_update_type,
+)
+from git_theta import file_io
+from git_theta import params
+from git_theta import git_utils
+
+
+class SparseUpdate(Update):
+    """An update where only some of the parameters are touched."""
+
+    @property
+    def name(self):
+        """The name used to get this class as a plugin."""
+        return "sparse"
+
+    def read(self, path: str) -> np.ndarray:
+        """Read the parameter values in the path dir.
+
+        Note:
+            The values read from disk are just the sparse update values, they
+            need to be combined with the previous parameter values before they
+            can be used.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path that contains parameter
+            update values.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter values at path.
+        """
+        # TODO: Update sparse to use actual sparse representations
+        logging.debug(f"Reading sparse update from '{path}'")
+        return file_io.load_tracked_file(path)
+
+    def calculate_sparse_update(self, new_value, previous_value):
+        """Get the sparse update whose application to previous value yields new value."""
+        # TODO: Update sparse to use actual sparse representations
+        return new_value - previous_value
+
+    def _previous_update(self, path: str) -> str:
+        """Find the last update applied to this parameter via the update metadata file.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path that for the current
+            update
+
+        Returns
+        -------
+        str
+            The .../param/update/${hash}' directory path for the /last/ update
+            applied to this parameter.
+        """
+        metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
+        metadata = file_io.load_staged_file(metadata_file)
+        return metadata[UpdateConstants.PREVIOUS_KEY]
+
+    def get_previous_value(self, path: str) -> np.ndarray:
+        """Load the last parameter value.
+
+        Parameters
+        ----------
+        path
+            The .../param/update/${hash} directory path for the /last/ update
+            applied to this parameter.
+
+        Returns
+        -------
+        np.ndarray
+            The previous parameter value, calculated by recursively calling the
+            update class for the previous update.
+        """
+        # Get the update type information from the update metadata file.
+        update_type = read_update_type(path)
+        update = get_update_handler(update_type)()
+        return update.apply(path)
+
+    def write(self, path, parameter: np.ndarray):
+        """Write `parameter` values to path.
+
+        Note:
+            Writing the sparse update between the previous parameters and the
+            current parameters requires getting the previous values (recursively),
+            calculating the sparse update, and writing that update to disk.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to write to.
+        parameter
+            The values to write.
+        """
+        logging.debug(f"Calculating sparse update to '{path}'")
+        # Our update dirs are named based on the hash of the parameter after all
+        # updates are applied, not based on the hash of the actual update.
+        parameter_hash = params.get_hash(parameter)
+        output_dir = os.path.join(path, UpdateConstants.UPDATES_DIR, parameter_hash)
+        # When we are adding a new update, the last update will be the most
+        # recent update that touched this parameter.
+        previous_update = most_recent_update(path)
+        logging.debug(f"The last time '{path}' was updated was in '{previous_update}'")
+        # Convert that most recent path to an absolute path and use it to load
+        # the most recent value of the parameter.
+        repo = git_utils.get_git_repo()
+        logging.debug("Recursively fetching the most recent value of the parameter.")
+        previous = self.get_previous_value(
+            git_utils.get_absolute_path(git_utils.get_git_repo(), previous_update)
+        )
+        logging.debug(f"Writing sparse update to '{output_dir}'")
+        difference = self.calculate_sparse_update(parameter, previous)
+        # Save the sparse update (not the final parameters).
+        file_io.write_tracked_file(output_dir, difference)
+        # Save update information, i.e. that this is a sparse update date.
+        # Save the previous update to track what parameter out update is applied to.
+        file_io.write_staged_file(
+            os.path.join(output_dir, UpdateConstants.METADATA_FILE),
+            {
+                UpdateConstants.UPDATE_KEY: self.name,
+                UpdateConstants.PREVIOUS_KEY: previous_update,
+            },
+        )
+        # Update the parameter metadata file setting this update as the most recent one.
+        self.record_update(path, output_dir)
+
+    def apply(self, path) -> np.ndarray:
+        """Get the update parameter values after applying the update from `path`.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to the update we want
+            the result from.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter after the update at `path` is applied.
+        """
+        logging.debug(f"Applying sparse update to '{path}'")
+        previous_update = self._previous_update(path)
+        logging.debug(f"The last time '{path}' was updated was in '{previous_update}'")
+        # Get the last parameter value.
+        previous = self.get_previous_value(previous_update)
+        # Read the sparse update from disk
+        difference = self.read(path)
+        # Apply the sparse update to the previous parameter values.
+        return previous + difference

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Install the git-theta package."""
 
 import ast
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def get_version(file_name: str, version_variable: str = "__version__") -> str:
@@ -45,7 +45,7 @@ setup(
     author="Colin Raffel",
     author_email="craffel@gmail.com",
     url="https://github.com/r-three/checkpoint-vcs",
-    packages=["git_theta"],
+    packages=find_packages(),
     scripts=["bin/git-theta", "bin/git-theta-filter"],
     long_description="Version control system for model checkpoints.",
     python_requires=">=3.6",
@@ -72,6 +72,10 @@ setup(
         "git_theta.plugins.checkpoints": [
             "pytorch = git_theta.checkpoints:PickledDictCheckpoint",
             "pickled-dict = git_theta.checkpoints:PickledDictCheckpoint",
-        ]
+        ],
+        "git_theta.plugins.updates": [
+            "dense = git_theta.updates.dense:DenseUpdate",
+            "sparse = git_theta.updates.sparse:SparseUpdate",
+        ],
     },
 )

--- a/tests/updates/base_test.py
+++ b/tests/updates/base_test.py
@@ -1,0 +1,64 @@
+"""Tests for common update plugin functions."""
+
+import os
+import pytest
+from git_theta.updates import base
+from git_theta import utils
+
+
+@pytest.fixture
+def env_var():
+    current_env = dict(os.environ)
+    os.environ[utils.EnvVarConstants.UPDATE_TYPE] = "sparse"
+
+    yield
+    os.environ.clear()
+    os.environ.update(current_env)
+
+
+@pytest.fixture
+def no_env_var():
+    current_env = dict(os.environ)
+    os.environ.pop(utils.EnvVarConstants.UPDATE_TYPE, None)
+
+    yield
+    os.environ.clear()
+    os.environ.update(current_env)
+
+
+@pytest.fixture
+def empty_env_var():
+    current_env = dict(os.environ)
+    os.environ[utils.EnvVarConstants.UPDATE_TYPE] = ""
+
+    yield
+    os.environ.clear()
+    os.environ.update(current_env)
+
+
+def test_get_update_handler_name_prefers_user_input(env_var):
+    """Ensure that user input is always used if provided."""
+    user_input = "low-rank"
+    assert os.environ.get(utils.EnvVarConstants.UPDATE_TYPE) == "sparse"
+    assert base.get_update_handler_name(user_input) == user_input
+
+
+def test_get_update_handler_name_uses_env_variable(env_var):
+    """Ensure env variables are checked before defaulting."""
+    user_input = None
+    assert base.get_update_handler_name(user_input) == "sparse"
+
+
+def test_get_update_handler_name_default(no_env_var):
+    """Ensure there is a default when there is no input and no defined env var."""
+    user_input = None
+    assert os.environ.get(utils.EnvVarConstants.UPDATE_TYPE) is None
+    assert base.get_update_handler_name(user_input) == "dense"
+
+
+def test_get_update_handler_name_empty_env(empty_env_var):
+    """Ensure there is a default when there is no input and a defined, but empty, env var."""
+    user_input = None
+    assert utils.EnvVarConstants.UPDATE_TYPE in os.environ
+    assert os.environ[utils.EnvVarConstants.UPDATE_TYPE] == ""
+    assert base.get_update_handler_name(user_input) == "dense"


### PR DESCRIPTION
This PR adds support for parameter updates, where the parameter value at timestep t is computed as an update to timestep t-1. The update value is what is stored on disk instead of the actual parameter at timestep t. When the parameter at timestep t in reconstituted in a git smudge, it is computed by applying the update (loaded from disk) to the parameter at timestep t-1.

We track updates on the filesystem using a slightly updated structure. Each network parameter still has a `.../params/` directory, but instead of the parameters living directly in that directory, they live in a `.../params/updates/${hash}/` directory. This hash is the hash of the parameters at timestep t, not the hash of the update on disk.

Additionally there is now a `.../params/metadata` file that tracks what the last update to be made to these parameters was. There is also a `.../params/updates/${hash}/metadata` file. This tracks what kind of update was used and what the previous update was.

Now reconstituting via a smudge is done by creating the update plugin used for the most recent update and calling `.apply` on it. This will get the value of the parameter after that update was applied. True updates, like sparse, will recursively get the parameter value at timestep t-1 by creating and applying the update plugin used in the previous update. It will then apply it's own update to the result.

Updates that touch all the parameters, for example a dense update, act as base cases. They don't track what the last update was or call plugin used for the last update, they just return the parameter values as they were at some timestep i (read directly from disk).

I opted to implement this recursive update (where each update keeps a backpointer to the update before it) instead of a list of updates implementation we has discussed as it allow us to skip the creation of parameter t-1 when the update at t is not a true update (dense).

The on-disk format for parameters is more complex/verbose now, but the shared format for different update types makes manipulation easy, additionally, naming updates by the hash of the resulting parameter (instead of the update values) should allow for an easy implementation for things like `git theta compact` which could collapse a series of sparse updates into a single update.

This PR also adds some tests to the cascading override behavior we use when determining what update type to use based on various methods of capturing user input.