### PR TITLE
Update black to be run on the `bin/` files.

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/bin/git-theta
+++ b/bin/git-theta
@@ -60,14 +60,16 @@ def add(args):
     checkpoint_handler = checkpoints.get_checkpoint_handler(args.type)
     logging.debug(f"git theta add using checkpoint type={checkpoint_handler.name}")
     param_dict = checkpoint_handler.from_file(args.file)
-    
+
     for param_dir, param in paths_and_parameters(param_dict, theta_model_dir).items():
         param_file = os.path.join(param_dir, "params")
         os.makedirs(param_file, exist_ok=True)
         file_io.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
 
-    for param_file in utils.removed_params(param_dict, utils.walk_parameter_dir(theta_model_dir)):
+    for param_file in utils.removed_params(
+        param_dict, utils.walk_parameter_dir(theta_model_dir)
+    ):
         git_utils.remove_file(param_file, repo)
 
     git_utils.add_file(model_path, repo)
@@ -102,7 +104,9 @@ def track(args):
     gitattributes_file = git_utils.get_gitattributes_file(repo)
     gitattributes = git_utils.read_gitattributes(gitattributes_file)
 
-    new_gitattributes = git_utils.add_filter_theta_to_gitattributes(gitattributes, model_path)
+    new_gitattributes = git_utils.add_filter_theta_to_gitattributes(
+        gitattributes, model_path
+    )
 
     git_utils.write_gitattributes(gitattributes_file, new_gitattributes)
     git_utils.add_file(gitattributes_file, repo)

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -63,7 +63,9 @@ def clean(args):
 
     repo = git_utils.get_git_repo()
     model_path = git_utils.get_relative_path_from_root(repo, args.file)
-    theta_model_dir = git_utils.get_relative_path_from_root(repo, git_utils.get_git_theta_model_dir(repo, model_path))
+    theta_model_dir = git_utils.get_relative_path_from_root(
+        repo, git_utils.get_git_theta_model_dir(repo, model_path)
+    )
 
     checkpoint_handler = checkpoints.get_checkpoint_handler()
     model_checkpoint = checkpoint_handler.from_file(sys.stdin.buffer)
@@ -77,7 +79,9 @@ def clean(args):
         tensor_metadata = OrderedDict({"shape": params.get_shape_str(param)})
         tensor_metadata["dtype"] = params.get_dtype_str(param)
         tensor_metadata["hash"] = params.get_hash(param)
-        staged_file_contents[param_name] = OrderedDict({"tensor_metadata": tensor_metadata})
+        staged_file_contents[param_name] = OrderedDict(
+            {"tensor_metadata": tensor_metadata}
+        )
 
     file_io.write_staged_file(sys.stdout, staged_file_contents)
 
@@ -92,9 +96,9 @@ def smudge(args):
     staged_file = file_io.load_staged_file(sys.stdin)
 
     model_dict = {}
-    for keys, param_dir in utils.flatten(utils.walk_parameter_dir(
-        os.path.abspath(staged_file["model_dir"])
-    )).items():
+    for keys, param_dir in utils.flatten(
+        utils.walk_parameter_dir(os.path.abspath(staged_file["model_dir"]))
+    ).items():
         param_file = os.path.join(param_dir, "params")
         logging.debug(f"Populating model parameter {'/'.join(keys)}")
         model_dict[keys] = file_io.load_tracked_file(param_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+include = '((\.pyi?|\.ipynb)$|bin/)'


### PR DESCRIPTION
When run from CI (github actions) or manually, black uses the configuration found in the new `pyproject.toml` file. This has an updated include regex that matches our bin scripts. This means black will format these files and CI will error when these files are unformatted.

When triggered via pre-commit black does not find its own files, instead it is passed a list of files by pre-commit, i.e. the include flag is ignore. This PR makes our bin files as executable. This change makes the `identify` library that pre-commit uses to find python files recognize that these are python scripts based on the `#!` line. This update means that black is automatically applied to these file on commit.

I have verified these changes result in the `bin/` files getting processed.

Via pre-commit
```bash
$ git commit -m test-black
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted bin/git-theta-filter
reformatted bin/git-theta

All done! ✨ 🍰 ✨
2 files reformatted.
```

Via CI, see [this failed ci run](https://github.com/blester125/git-theta/actions/runs/3534350347) because of misformatted bin files 

closes https://github.com/r-three/git-theta/issues/88