### PR TITLE
Add the beginning of optional framework installs

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Dependencies and Package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[test]
+        python -m pip install .[test,all]
     - name: Run Unit Tests
       run: |
         pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Dependencies and Package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[test,all]
+        python -m pip install .[test,pytorch]
     - name: Run Unit Tests
       run: |
         pytest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ cd git-theta
 pip install .[pytorch]
 ```
 
+If you already have your framework of choice installed (i.e. pip doesn't need
+to ensure it is installed), you can just install git-theta with `pip install .`
+
 ## Initializing git theta
 Initialize git theta by running:
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,8 +14,23 @@ git clone https://github.com/r-three/git-theta.git
 Install the git-theta package by running:
 ```bash
 cd git-theta
-pip install .
+pip install .[all]
 ```
+
+### A Single Deep Learning Framework
+
+If you plan to track model checkpoints created by a single deep learning
+framework, for example only PyTorch or only Tensorflow, you can elect to only
+ensure the framework you use will be installed, avoiding the long install times
+and possible version requirements issues installing unused frameworks may bring.
+
+For example, install git-theta with only pytorch checkpoint support:
+
+``` bash
+cd git-theta
+pip install .[pytorch]
+```
+
 ## Initializing git theta
 Initialize git theta by running:
 ```bash

--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -1,6 +1,5 @@
 """Backends for different checkpoint formats."""
 
-import torch
 import os
 import json
 import io
@@ -86,6 +85,12 @@ class PickledDictCheckpoint(Checkpoint):
             Dictionary mapping parameter names to parameter values. Parameters
             should be numpy arrays.
         """
+        # TODO(bdlester): Once multiple checkpoint types are supported and
+        # this checkpoint object is moved to its own module, move this import
+        # back to toplevel. Currently it is inside the object methods to allow
+        # for optional framework installs.
+        import torch
+
         model_dict = torch.load(io.BytesIO(checkpoint_path.read()))
         if not isinstance(model_dict, dict):
             raise ValueError("Supplied PyTorch checkpoint must be a dict.")
@@ -103,6 +108,12 @@ class PickledDictCheckpoint(Checkpoint):
         checkpoint_path : str or file-like object
             Path to write out the checkpoint file to
         """
+        # TODO(bdlester): Once multiple checkpoint types are supported and
+        # this checkpoint object is moved to its own module, move this import
+        # back to toplevel. Currently it is inside the object methods to allow
+        # for optional framework installs.
+        import torch
+
         checkpoint_dict = {k: torch.as_tensor(v) for k, v in self.items()}
         torch.save(checkpoint_dict, checkpoint_path)
 

--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -7,7 +7,6 @@ import json
 import logging
 import io
 import re
-import torch
 from typing import List, Union
 import subprocess
 

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     license="MIT",
     install_requires=[
         "GitPython",
+        # TODO: Remove torch as a default requirement once the params module is updated.
         "torch",
         "tensorstore",
         "file-or-name",
@@ -67,6 +68,10 @@ setup(
     ],
     extras_require={
         "test": ["pytest"],
+        "pytorch": ["torch"],
+        "tensorflow": ["tensorflow"],
+        # TODO: Add tensorflow to the all target once tf checkpoint support is added.
+        "all": ["torch"],
     },
     entry_points={
         "git_theta.plugins.checkpoints": [

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,6 @@ setup(
     license="MIT",
     install_requires=[
         "GitPython",
-        # TODO: Remove torch as a default requirement once the params module is updated.
-        "torch",
         "tensorstore",
         "file-or-name",
         "importlib_metadata",


### PR DESCRIPTION
This PR adds the ability to install specific frameworks with git-theta using the `extras_require` feature of pip. This lets one install only the deep learning frameworks they plan to use.

Working towards https://github.com/r-three/git-theta/issues/85

This should be merged but the feature isn't useful until ~https://github.com/r-three/git-theta/issues/94 and https://github.com/r-three/git-theta/issues/79 are fixed~ https://github.com/r-three/git-theta/issues/79 is done