### PR TITLE
Convert Env Var lookup from strings to named constants.

### DIFF
--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -68,7 +68,7 @@ def clean(args):
     # TODO(bdlester): Find a better way to include checkpoint type information
     # in git clean filters that are run without `git theta add`.
     # TODO: Don't default to pytorch once other checkpoint formats are supported.
-    checkpoint_type = os.environ.get("GIT_THETA_CHECKPOINT_TYPE") or "pytorch"
+    checkpoint_type = os.environ.get(utils.EnvVarConstants.CHECKPOINT_TYPE) or "pytorch"
     checkpoint = checkpoints.get_checkpoint(checkpoint_type)
     logging.debug("git theta clean filter using checkpoint_type={checkpoint.name}")
     model_checkpoint = checkpoint.from_file(sys.stdin.buffer)

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -6,6 +6,11 @@ import os
 from typing import Dict, Any, Tuple, Union, Callable
 
 
+class EnvVarConstants:
+    CHECKPOINT_TYPE: str = "GIT_THETA_CHECKPOINT_TYPE"
+    UPDATE_TYPE: str = "GIT_THETA_UPDATE_TYPE"
+
+
 def flatten(d: Dict[str, Any]) -> Dict[Tuple[str, ...], Any]:
     """Flatten a nested dictionary.
 


### PR DESCRIPTION
This PR updates the usage of environment variables to use named constants (scoped within a class) instead of raw string values.

closes https://github.com/r-three/git-theta/issues/96, but depending on what is merged first, this or a few other PRs that use the environment variables will need to be updated.