### PR TITLE
Remove `iterate_*_leaves` functions.

### DIFF
--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -15,9 +15,6 @@ from file_or_name import file_or_name
 
 from . import utils
 
-# Maintain access via checkpoints module for now.
-from .utils import iterate_dict_leaves, iterate_dir_leaves
-
 
 class Checkpoint(dict):
     """Abstract base class for wrapping checkpoint formats."""
@@ -97,44 +94,6 @@ class PickledDictCheckpoint(Checkpoint):
         """
         checkpoint_dict = {k: torch.as_tensor(v) for k, v in self.items()}
         torch.save(checkpoint_dict, checkpoint_path)
-
-
-def iterate_dir_leaves(root):
-    """
-    Generator that iterates through files in a directory tree and produces (path, dirs) tuples where
-    path is the file's path and dirs is the sequence of path components from root to the file.
-
-    Example
-    -------
-    root
-    ├── a
-    │   ├── c
-    │   └── d
-    └── b
-        └── e
-
-    iterate_dir_leaves(root) --> ((root/a/c, ['a','c']), (root/a/d, ['a','d']), (root/b/e, ['b','e']))
-
-    Parameters
-    ----------
-    root : str
-        Root of directory tree to iterate over
-
-    Returns
-    -------
-    generator
-        generates directory tree leaf, subdirectory list tuples
-    """
-
-    def _iterate_dir_leaves(root, prefix):
-        for d in os.listdir(root):
-            dir_member = os.path.join(root, d)
-            if not "params" in os.listdir(dir_member):
-                yield from _iterate_dir_leaves(dir_member, prefix=prefix + [d])
-            else:
-                yield (dir_member, prefix + [d])
-
-    return _iterate_dir_leaves(root, [])
 
 
 def get_checkpoint(checkpoint_type: str) -> Checkpoint:

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -6,62 +6,6 @@ import os
 from typing import Dict, Any, Tuple, Union, Callable
 
 
-def iterate_dict_leaves(d):
-    """
-    Generator that iterates through a dictionary and produces (leaf, keys) tuples where leaf is a dictionary leaf
-    and keys is the sequence of keys used to access leaf. Dictionary is iterated in depth-first
-    order with lexicographic ordering of keys.
-
-    Example
-    -------
-    d = {'a': {'b': {'c': 10, 'd': 20, 'e': 30}}}
-    iterate_dict_leaves(d) --> ((10, ['a','b','c']), (20, ['a','b','d']), (30, ['a','b','e']))
-
-    Parameters
-    ----------
-    d : dict
-        dictionary to iterate over
-
-    Returns
-    -------
-    generator
-        generates dict leaf, key path tuples
-    """
-    yield from map(lambda kv: (kv[1], list(kv[0])), sorted(flatten(d).items()))
-
-
-def iterate_dir_leaves(root):
-    """
-    Generator that iterates through files in a directory tree and produces (path, dirs) tuples where
-    path is the file's path and dirs is the sequence of path components from root to the file.
-
-    Example
-    -------
-    root
-    ├── a
-    │   ├── c
-    │   └── d
-    └── b
-        └── e
-
-    iterate_dir_leaves(root) --> ((root/a/c, ['a','c']), (root/a/d, ['a','d']), (root/b/e, ['b','e']))
-
-    Parameters
-    ----------
-    root : str
-        Root of directory tree to iterate over
-
-    Returns
-    -------
-    generator
-        generates directory tree leaf, subdirectory list tuples
-    """
-    yield from map(
-        lambda kv: (kv[1], list(kv[0])),
-        sorted(flatten(walk_parameter_dir(root)).items()),
-    )
-
-
 def flatten(d: Dict[str, Any]) -> Dict[Tuple[str, ...], Any]:
     """Flatten a nested dictionary.
 


### PR DESCRIPTION
This PR removes the `iterate_*_leaves` function which we weren't using anymore. It also translates the tests for those functions to the underlying flat-map based functions we are using now.

closes https://github.com/r-three/git-theta/issues/83