### PR TITLE
Update the parameter functions to remove torch dep

### DIFF
--- a/git_theta/checkpoints.py
+++ b/git_theta/checkpoints.py
@@ -45,7 +45,8 @@ class Checkpoint(dict):
         Returns
         -------
         model_dict : dict
-            Dictionary mapping parameter names to parameter values
+            Dictionary mapping parameter names to parameter values. Parameters
+            should be numpy arrays.
         """
         raise NotImplementedError
 
@@ -76,7 +77,8 @@ class PickledDictCheckpoint(Checkpoint):
         Returns
         -------
         model_dict : dict
-            Dictionary mapping parameter names to parameter values
+            Dictionary mapping parameter names to parameter values. Parameters
+            should be numpy arrays.
         """
         model_dict = torch.load(io.BytesIO(checkpoint_path.read()))
         if not isinstance(model_dict, dict):

--- a/git_theta/params.py
+++ b/git_theta/params.py
@@ -1,5 +1,7 @@
+"""Utilties to summarize parameters."""
+
 import hashlib
-import torch
+import numpy as np
 
 
 def get_shape_str(p):
@@ -13,7 +15,7 @@ def get_shape_str(p):
     str
         shape of parameter
     """
-    return str(torch.tensor(p).numpy().shape)
+    return str(np.asarray(p).shape)
 
 
 def get_dtype_str(p):
@@ -27,7 +29,7 @@ def get_dtype_str(p):
     str
         dtype of parameter
     """
-    return torch.tensor(p).numpy().dtype.str
+    return np.asarray(p).dtype.str
 
 
 def get_hash(p):
@@ -41,4 +43,4 @@ def get_hash(p):
     str
         hash of parameter bytes
     """
-    return hashlib.sha1(torch.tensor(p).numpy().tobytes()).hexdigest()
+    return hashlib.sha1(np.asarray(p).tobytes()).hexdigest()

--- a/tests/params_test.py
+++ b/tests/params_test.py
@@ -1,0 +1,67 @@
+"""Test utilities that summarize parameters."""
+
+import random
+import pytest
+import numpy as np
+from git_theta import params
+
+
+def test_get_shape():
+    num_dims = np.random.randint(2, 5)
+    shape = tuple(np.random.randint(1, 20, size=num_dims).tolist())
+    t = np.random.rand(*shape)
+    assert params.get_shape_str(t) == str(shape)
+
+
+def test_get_shape_list():
+    shape = np.random.randint(10, 20)
+    t = [random.randint(2, 19) for _ in range(shape)]
+    assert params.get_shape_str(t) == str((shape,))
+
+
+def test_get_shape_list_2d():
+    batch, seq = np.random.randint(10, 20, size=2)
+    t = []
+    for _ in range(batch):
+        t_ = []
+        for _ in range(seq):
+            t_.append(random.randint(0, 10))
+        t.append(t_)
+    assert params.get_shape_str(t) == str((batch, seq))
+
+
+def test_get_shape_scalar():
+    t = 12
+    assert params.get_shape_str(t) == "()"
+
+
+def test_get_dtype_str():
+    for dtype in (np.int32, np.uint8, np.float32, np.float64, np.int64):
+        t = np.ones((10, 10), dtype=dtype)
+        assert params.get_dtype_str(t) == np.dtype(dtype).str
+
+
+def test_get_dtype_list_scalar():
+    for dtype, convert in (("<f8", float), ("<i8", int)):
+        t = [convert(random.randint(0, 100)) for _ in range(10)]
+        assert params.get_dtype_str(t) == dtype
+        s = convert(random.randint(0, 100))
+        assert params.get_dtype_str(t) == dtype
+
+
+def test_get_hash():
+    # We can't really test the hashing, so test that same values hash
+    # equal and non-equal hash different.
+    t = np.random.rand(3, 4, 5)
+    t_ = t.copy()
+    # Make sure we aren't referencing the same object
+    assert t is not t_
+    # Make sure things with the same value hash to the same
+    np.testing.assert_allclose(t, t_)
+    assert params.get_hash(t) == params.get_hash(t_)
+
+    # Make sure that things with different values hash to different things.
+    t_update = np.random.rand(*t.shape)
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(t, t_update)
+    assert params.get_hash(t) != params.get_hash(t_update)


### PR DESCRIPTION
This PR updates the functions in the `git_theta.params` module to remove the dependency on pytorch. Instead it operates using numpy arrays.

This also adds tests that we are extracting the right values from the parameters.

This also updates some of the docstrings on the checkpoint plugin classes to highlight that the processed model dict should be using numpy arrays instead of framework native tensors.

When we eventually work with non-standard dtypes (`jnp.bfloat16` for example) we may need to revisit the initial call to `np.asarray`.

closes https://github.com/r-three/git-theta/issues/94