### PR TITLE
Refactor Update plugins

### DIFF
--- a/git_theta/updates/__init__.py
+++ b/git_theta/updates/__init__.py
@@ -1,6 +1,7 @@
 """Classes for controlling how parameter updates are made."""
 
 from git_theta.updates.base import (
+    TrueUpdate,
     Update,
     get_update_handler,
     UpdateConstants,

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -40,9 +40,9 @@ Example directory structure of how updates are stored.
 
 
 Example .../layers.0.bias/params/metadata
-[
-    ".git_theta/my-model.pt/layers.0.bias/params/updates/77db6ed78df01aecbb9e7990a87d50f7dc2d5579"
-]
+{
+    "previous": ".git_theta/my-model.pt/layers.0.bias/params/updates/77db6ed78df01aecbb9e7990a87d50f7dc2d5579"
+}
 
 Example .../params/updates/${hash}/metadata
 {
@@ -55,11 +55,16 @@ Another Example
     "update": "dense"
 }
 
+Note:
+    Metadata paths should be recorded as relative paths from the repo root, i.e.
+    `.git_theta/...`.
 """
 
+from abc import ABCMeta, abstractmethod
 import logging
 import os
 import sys
+from typing import Dict, Any, Optional
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -72,6 +77,7 @@ import numpy as np
 from git_theta import file_io
 from git_theta import git_utils
 from git_theta import utils
+from git_theta import params
 
 
 class UpdateConstants:
@@ -83,7 +89,7 @@ class UpdateConstants:
     PREVIOUS_KEY: str = "previous"
 
 
-class Update:
+class Update(metaclass=ABCMeta):
     """Base class for parameter update plugins."""
 
     @property
@@ -91,6 +97,7 @@ class Update:
         """The name used to get this class as a plugin."""
         raise NotImplementedError
 
+    @abstractmethod
     def read(self, path: str) -> np.ndarray:
         """Read the parameter values in the path dir.
 
@@ -107,6 +114,7 @@ class Update:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def write(self, path: str, parameter: np.ndarray):
         """Write `parameter` values to path.
 
@@ -119,6 +127,7 @@ class Update:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def apply(self, path: str) -> np.ndarray:
         """Get the update parameter values after applying the update from `path`.
 
@@ -135,6 +144,20 @@ class Update:
         """
         raise NotImplementedError
 
+    # TODO: Unify with record update?
+    def write_update_metadata(self, path: str, previous_path: Optional[str] = None):
+        # Save update information, i.e. what kind of update this is.
+        # Save the previous update to track what parameter out update is applied to.
+        if previous_path is not None:
+            # Save the previous update as a relative path.
+            metadata = {UpdateConstants.PREVIOUS_KEY: previous_path}
+        else:
+            metadata = {}
+        file_io.write_staged_file(
+            os.path.join(path, UpdateConstants.METADATA_FILE),
+            {UpdateConstants.UPDATE_KEY: self.name, **metadata},
+        )
+
     def record_update(self, path: str, update_path: str):
         """Update the most recent update metadata file to point to this update.
 
@@ -148,38 +171,179 @@ class Update:
         """
         metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
         if not os.path.exists(metadata_file):
-            metadata = []
+            metadata = {}
         else:
             metadata = file_io.load_staged_file(metadata_file)
         update_path = git_utils.get_relative_path_from_root(
             git_utils.get_git_repo(), update_path
         )
         logging.debug(
-            f"Recording recent update as '{update_path}' was '{metadata[-1] if metadata else None}'"
+            f"Recording recent update as '{update_path}' was '{metadata[UpdateConstants.PREVIOUS_KEY] if metadata else None}'"
         )
-        file_io.write_staged_file(metadata_file, [update_path])
+        file_io.write_staged_file(
+            metadata_file, {UpdateConstants.PREVIOUS_KEY: update_path}
+        )
+
+
+class TrueUpdate(Update):
+    """A base class for update types that use the previous parameter value."""
+
+    @abstractmethod
+    def write_update(path: str, update: np.ndarray):
+        """Write `update` values to path.
+
+        This is method is designed to be overridden with the logic to actually
+        serialize some update value to disk. It doesn't include logic on getting
+        the previous value.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to write to.
+        update
+            The values to write.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def calculate_update(self, new_value, previous_value):
+        """Calculate the update applied to previous value to yield new_value.
+
+        Parameters
+        ----------
+        new_value
+            The updated parameter value.
+        previous_value
+            What the parameter was after the last update.
+
+        Returns
+        -------
+        np.ndarray
+            The update to apply to previous_value to yield new_value
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_update(self, previous, update):
+        """Apply update to previous.
+
+        Parameters
+        ----------
+        previous
+            The old parameter values
+        update
+            The new update values
+
+        Returns
+        -------
+        np.ndarray
+            The new parameter value from applying update to previous.
+        """
+        raise NotImplementedError
+
+    def write(self, path: str, parameter: np.ndarray):
+        """Write `parameter` values to path.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to write to.
+        parameter
+            The values to write.
+        """
+        logging.debug(f"Calculating {self.name} update to '{path}'")
+        path = git_utils.get_absolute_path(git_utils.get_git_repo(), path)
+        # Our update dirs are named based on the hash of the parameter after all
+        # updates are applied, not based on the hash of the actual update.
+        parameter_hash = params.get_hash(parameter)
+        output_dir = os.path.join(path, UpdateConstants.UPDATES_DIR, parameter_hash)
+        # When we are adding a new update, the last update will be the most
+        # recent update that touched this parameter.
+        previous_update_pointer = most_recent_update(path)
+        logging.debug(
+            f"The last time '{path}' was updated was in '{previous_update_pointer}'"
+        )
+        previous_value = self.get_previous_value(previous_update_pointer)
+        # Calculate the update.
+        update = self.calculate_update(parameter, previous_value)
+        # Save the actual update to disk
+        self.write_update(output_dir, update)
+        # Save the metadata file for the update
+        self.write_update_metadata(output_dir, previous_update_pointer)
+        # Update the pointer to the most recent update.
+        self.record_update(path, output_dir)
+
+    def get_previous_value(self, path: str) -> np.ndarray:
+        """Load the last parameter value.
+
+        Parameters
+        ----------
+        path
+            The .../param/update/${hash} directory path for the /last/ update
+            applied to this parameter.
+
+        Returns
+        -------
+        np.ndarray
+            The previous parameter value, calculated by recursively calling the
+            update class for the previous update.
+        """
+        path = git_utils.get_absolute_path(git_utils.get_git_repo(), path)
+        # Get the update type information from the update metadata file.
+        update_type = read_update_type(path)
+        update = get_update_handler(update_type)()
+        return update.apply(path)
+
+    def apply(self, path: str) -> np.ndarray:
+        """Get the update parameter values after applying the update from `path`.
+
+        Parameters
+        ----------
+        path
+            The .../params/updates/${hash} directory path to the update we want
+            the result from.
+
+        Returns
+        -------
+        np.ndarray
+            The parameter after the update at `path` is applied.
+        """
+        logging.debug(f"Applying {self.name} update to '{path}'.")
+        path = git_utils.get_absolute_path(git_utils.get_git_repo(), path)
+        previous_update_pointer = most_recent_update(path)
+        logging.debug(
+            f"The last time '{path}' was updated was in '{previous_update_pointer}"
+        )
+        previous_value = self.get_previous_value(previous_update_pointer)
+        update = self.read(path)
+        return self.apply_update(previous_value, update)
 
 
 def most_recent_update(path: str) -> str:
     """Get the most recent update applied to the parameter.
 
     Note:
-        Path is expected to be a path to the params directory of a parameter.
-        It should be an absolute path.
+        If path is the `.../params` directory this returns the most recent
+        update for that parameter. If path is the `.../params/updates/${hash}`
+        directory this returns the most recent update relative to that update,
+        i.e. the previous update.
 
     Parameters
     ----------
     path
-        The path to the .../params dir for a parameter.
+        The path to the .../params dir for a parameter or the
+        .../params/updates/${hash} dir for some update.
 
     Returns
     -------
     str
         The path to the previous update for the parameter, relative to the repo root.
     """
+    # Convert to an absolute path.
+    path = git_utils.get_absolute_path(git_utils.get_git_repo(), path)
     metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
     metadata = file_io.load_staged_file(metadata_file)
-    return metadata[0] if metadata else None
+    return metadata.get(UpdateConstants.PREVIOUS_KEY) if metadata else None
 
 
 def read_update_type(path: str) -> str:

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -65,10 +65,7 @@ class DenseUpdate(Update):
         # Write all parameter values as is to the update directory.
         file_io.write_tracked_file(output_dir, parameter)
         # Record update type information in the update metadata file.
-        file_io.write_staged_file(
-            os.path.join(output_dir, UpdateConstants.METADATA_FILE),
-            {UpdateConstants.UPDATE_KEY: self.name},
-        )
+        self.write_update_metadata(output_dir)
         # Update the parameter metadata file setting this update as the most recent one.
         self.record_update(path, output_dir)
 

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -1,23 +1,12 @@
 """A class for handling sparse updates to parameters."""
 
-import json
 import logging
-import os
-from typing import Optional
 import numpy as np
-from git_theta.updates import (
-    Update,
-    UpdateConstants,
-    get_update_handler,
-    most_recent_update,
-    read_update_type,
-)
+from git_theta.updates import TrueUpdate
 from git_theta import file_io
-from git_theta import params
-from git_theta import git_utils
 
 
-class SparseUpdate(Update):
+class SparseUpdate(TrueUpdate):
     """An update where only some of the parameters are touched."""
 
     @property
@@ -48,117 +37,16 @@ class SparseUpdate(Update):
         logging.debug(f"Reading sparse update from '{path}'")
         return file_io.load_tracked_file(path)
 
-    def calculate_sparse_update(self, new_value, previous_value):
+    def calculate_update(self, new_value, previous_value):
         """Get the sparse update whose application to previous value yields new value."""
         # TODO: Update sparse to use actual sparse representations
         return new_value - previous_value
 
-    def _previous_update(self, path: str) -> str:
-        """Find the last update applied to this parameter via the update metadata file.
+    def apply_update(self, previous, update):
+        """Apply a sparse update."""
+        return previous + update
 
-        Parameters
-        ----------
-        path
-            The .../params/updates/${hash} directory path that for the current
-            update
-
-        Returns
-        -------
-        str
-            The .../param/update/${hash}' directory path for the /last/ update
-            applied to this parameter.
-        """
-        metadata_file = os.path.join(path, UpdateConstants.METADATA_FILE)
-        metadata = file_io.load_staged_file(metadata_file)
-        return metadata[UpdateConstants.PREVIOUS_KEY]
-
-    def get_previous_value(self, path: str) -> np.ndarray:
-        """Load the last parameter value.
-
-        Parameters
-        ----------
-        path
-            The .../param/update/${hash} directory path for the /last/ update
-            applied to this parameter.
-
-        Returns
-        -------
-        np.ndarray
-            The previous parameter value, calculated by recursively calling the
-            update class for the previous update.
-        """
-        # Get the update type information from the update metadata file.
-        update_type = read_update_type(path)
-        update = get_update_handler(update_type)()
-        return update.apply(path)
-
-    def write(self, path, parameter: np.ndarray):
-        """Write `parameter` values to path.
-
-        Note:
-            Writing the sparse update between the previous parameters and the
-            current parameters requires getting the previous values (recursively),
-            calculating the sparse update, and writing that update to disk.
-
-        Parameters
-        ----------
-        path
-            The .../params/updates/${hash} directory path to write to.
-        parameter
-            The values to write.
-        """
-        logging.debug(f"Calculating sparse update to '{path}'")
-        # Our update dirs are named based on the hash of the parameter after all
-        # updates are applied, not based on the hash of the actual update.
-        parameter_hash = params.get_hash(parameter)
-        output_dir = os.path.join(path, UpdateConstants.UPDATES_DIR, parameter_hash)
-        # When we are adding a new update, the last update will be the most
-        # recent update that touched this parameter.
-        previous_update = most_recent_update(path)
-        logging.debug(f"The last time '{path}' was updated was in '{previous_update}'")
-        # Convert that most recent path to an absolute path and use it to load
-        # the most recent value of the parameter.
-        repo = git_utils.get_git_repo()
-        logging.debug("Recursively fetching the most recent value of the parameter.")
-        previous = self.get_previous_value(
-            git_utils.get_absolute_path(git_utils.get_git_repo(), previous_update)
-        )
-        logging.debug(f"Writing sparse update to '{output_dir}'")
-        difference = self.calculate_sparse_update(parameter, previous)
+    def write_update(self, path, update):
+        logging.debug(f"Writing sparse update to '{path}'")
         # Save the sparse update (not the final parameters).
-        file_io.write_tracked_file(output_dir, difference)
-        # Save update information, i.e. that this is a sparse update date.
-        # Save the previous update to track what parameter out update is applied to.
-        file_io.write_staged_file(
-            os.path.join(output_dir, UpdateConstants.METADATA_FILE),
-            {
-                UpdateConstants.UPDATE_KEY: self.name,
-                UpdateConstants.PREVIOUS_KEY: previous_update,
-            },
-        )
-        # Update the parameter metadata file setting this update as the most recent one.
-        self.record_update(path, output_dir)
-
-    def apply(self, path) -> np.ndarray:
-        """Get the update parameter values after applying the update from `path`.
-
-        Parameters
-        ----------
-        path
-            The .../params/updates/${hash} directory path to the update we want
-            the result from.
-
-        Returns
-        -------
-        np.ndarray
-            The parameter after the update at `path` is applied.
-        """
-        logging.debug(f"Applying sparse update to '{path}'")
-        previous_update = self._previous_update(path)
-        logging.debug(f"The last time '{path}' was updated was in '{previous_update}'")
-        # Get the last parameter value.
-        previous = self.get_previous_value(previous_update)
-        # Read the sparse update from disk
-        difference = self.read(path)
-        # Apply the sparse update to the previous parameter values.
-        return previous + difference
+        file_io.write_tracked_file(path, update)


### PR DESCRIPTION
This PR updates the Update plugin base classes. There is still the original base-class with overrideable read, write, and apply, but there is also a new TrueUpdate class which has definitions for read, write, and apply that work under the assumption that this update is handled using the previous value. This class includes a few smaller method about calculating and applying updates to increase code reuse between true update plugins.

The new implementation allow for writing new checkpoint types really easily and makes understanding the implementation of the true updates easier. I looked at trying to include this in the original Base class but some of the Dense updates implementations of the helper methods would be strange NoOps and not really make sense.

This PR also updates the format of the parameter level metadata file (it is now a dict) to allow unification of "get most recent update" when talking about the whole parameter or the most recent update before the current update.