### PR TITLE
Update CI unittests to run python3.6 in an older ubuntu container.

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,6 +17,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9"]
+        # Python 3.6 is not available in the ubuntu-latest container github
+        # provides, so skip that configuration.
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.6"
+        # Python 3.6 is still in the ubuntu-20.04 container from github so
+        # test git-theta in that container instead.
+        include:
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This fixes the CI issues we have been having. The containers we run CI tests in come from GitHub and we have been using `ubuntu-latest` which isn't a fixed version. They recently moved latest from ubuntu 20.04 to 22 and with that change `python 3.6` was no longer available as it was EOL in December 2021.

The ubunutu 20.04 container still has python3.6 in it so we are testing it that container instead.

Closes https://github.com/r-three/git-theta/issues/113