### PR TITLE
Move to Async Read/Writes

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -7,7 +7,7 @@ import logging
 import re
 import fnmatch
 
-from git_theta import git_utils, utils, theta, metadata
+from git_theta import git_utils, utils, theta, metadata, async_utils
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -105,7 +105,7 @@ def pre_push(args):
         (l.group("remote_sha1"), l.group("local_sha1")) for l in lines_parsed
     ]
     oids = theta_commits.get_commit_oids_ranges(*commit_ranges)
-    git_utils.git_lfs_push_oids(args.remote_name, oids)
+    async_utils.run(git_utils.git_lfs_push_oids(args.remote_name, oids))
 
 
 def install(args):

--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -4,7 +4,7 @@ import argparse
 import sys
 import logging
 
-from git_theta import git_utils, checkpoints, params, metadata, updates
+from git_theta import git_utils, checkpoints, params, metadata, updates, async_utils
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -60,37 +60,42 @@ def clean(args):
     model_checkpoint = checkpoint_handler.from_file(sys.stdin.buffer)
 
     prev_metadata = metadata.Metadata.from_commit(repo, args.file, "HEAD").flatten()
-    new_metadata = metadata.Metadata()
-    # Sort the keys so we don't get changing diffs based on serialization order.
-    for param_keys, new_param in sorted(model_checkpoint.flatten().items()):
-        logging.debug(f"Cleaning {'/'.join(param_keys)}")
 
+    async def _clean(param_keys, new_param):
+        logging.debug(f"Cleaning {'/'.join(param_keys)}")
         param_metadata = prev_metadata.get(param_keys)
         new_tensor_metadata = metadata.TensorMetadata.from_tensor(new_param)
         # If the parameter tensor has not changed, just keep the metadata the same
         # TODO: currently checks if rounded parameter hash has changed. Look into better parameter equality checks.
         if param_metadata and param_metadata.tensor_metadata == new_tensor_metadata:
-            new_param_metadata = param_metadata
-        # If it's changed, update this parameter's metadata
-        else:
-            update_handler = updates.get_update_handler()()
-            update_serializer = params.get_update_serializer()
+            return param_keys, param_metadata
 
-            new_theta_metadata = metadata.ThetaMetadata(
-                update_type=update_handler.name, last_commit=git_utils.get_head(repo)
-            )
-            param_update = update_handler.calculate_update(
-                repo, args.file, param_keys, param_metadata, new_param
-            )
-            serialized_update = update_serializer.serialize(param_update)
-            new_lfs_metadata = metadata.LfsMetadata.from_bytes(serialized_update)
-            new_param_metadata = metadata.ParamMetadata(
-                lfs_metadata=new_lfs_metadata,
-                tensor_metadata=new_tensor_metadata,
-                theta_metadata=new_theta_metadata,
-            )
+        update_serializer = params.get_update_serializer()
+        update_handler = updates.get_update_handler()(update_serializer)
+        new_theta_metadata = metadata.ThetaMetadata(
+            update_type=update_handler.name, last_commit=git_utils.get_head(repo)
+        )
+        lfs_metadata = await update_handler.write(
+            new_param,
+            param_keys,
+            param_metadata=param_metadata,
+            repo=repo,
+            path=args.file,
+        )
 
-        new_metadata[param_keys] = new_param_metadata
+        new_param_metadata = metadata.ParamMetadata(
+            lfs_metadata=lfs_metadata,
+            tensor_metadata=new_tensor_metadata,
+            theta_metadata=new_theta_metadata,
+        )
+        return param_keys, new_param_metadata
+
+    # Sort the keys so we don't get changing diffs based on serialization order.
+    sorted_checkpoint = dict(sorted(model_checkpoint.flatten().items()))
+    new_metadata = metadata.Metadata(
+        **async_utils.run(async_utils.run_map(sorted_checkpoint, _clean))
+    )
+
     new_metadata.unflatten().write(sys.stdout)
 
 
@@ -103,15 +108,17 @@ def smudge(args):
     repo = git_utils.get_git_repo()
     curr_metadata = metadata.Metadata.from_file(sys.stdin).flatten()
 
-    model_dict = {}
-    for param_keys, param_metadata in curr_metadata.items():
+    async def _smudge(param_keys, param_metadata):
         logging.debug(f"Smudging {'/'.join(param_keys)}")
         update_handler = updates.get_update_handler(
             param_metadata.theta_metadata.update_type
-        )()
-        model_dict[param_keys] = update_handler.apply(
-            repo, args.file, param_keys, param_metadata
+        )(params.get_update_serializer())
+        param_value = await update_handler.apply(
+            param_metadata, param_keys, repo=repo, path=args.file
         )
+        return param_keys, param_value
+
+    model_dict = async_utils.run(async_utils.run_map(curr_metadata, _smudge))
 
     checkpoint_handler = checkpoints.get_checkpoint_handler()
     model_checkpoint = checkpoint_handler(model_dict).unflatten()

--- a/git_theta/async_utils.py
+++ b/git_theta/async_utils.py
@@ -1,0 +1,87 @@
+"""Utilities for running I/O-bound operations asyncronously."""
+
+import asyncio
+import dataclasses
+import sys
+from typing import (
+    Any,
+    Dict,
+    Tuple,
+    TypeVar,
+    Awaitable,
+    Union,
+    Optional,
+    Sequence,
+)
+import six
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
+
+def run(*args, **kwargs):
+    """Run an awaitable to completion, dispatch based on python version."""
+    # TODO(bdlester): Remove if we bump to python 3.7
+    if sys.version_info < (3, 7):
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(*args, **kwargs)
+    return asyncio.run(*args, **kwargs)
+
+
+# A type variable to indicate that the keys of the dict will not change.
+K = TypeVar("K")
+# A type variable to indicate that the async task is called with K, V tuples.
+V = TypeVar("V")
+
+
+class MapTask(Protocol):
+    def __call__(self, key: K, value: V) -> Awaitable[Tuple[K, Any]]:
+        """An async function that runs on each key, value pair in a map."""
+
+
+async def run_map(
+    mapping: Dict[K, V],
+    func: MapTask,
+) -> Dict[K, Any]:
+    """Run async function on K, V pairs, return map with result as new value."""
+    return dict(await asyncio.gather(*(func(k, v) for k, v in mapping.items())))
+
+
+@dataclasses.dataclass
+class CompletedAsyncProcess:
+    """Results from a finished async subprocess run."""
+
+    args: Union[Sequence[str], str]
+    returncode: Optional[int]
+    stdout: Optional[bytes] = None
+    stderr: Optional[bytes] = None
+
+
+async def subprocess_run(
+    command: Union[Sequence[str], str],
+    input: Optional[Union[str, bytes]] = None,
+    capture_output: bool = False,
+) -> CompletedAsyncProcess:
+    """Run a subprocess with async. Tries to mirror the subprocess.run API."""
+    if not isinstance(command, str):
+        shell_command = " ".join(command)
+    else:
+        shell_command = command
+    proc = await asyncio.create_subprocess_shell(
+        shell_command,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    if input is not None:
+        stdout, stderr = await proc.communicate(input=six.ensure_binary(input))
+    else:
+        stdout, stderr = await proc.communicate()
+    return CompletedAsyncProcess(
+        command,
+        proc.returncode,
+        stdout if capture_output else None,
+        stderr if capture_output else None,
+    )

--- a/git_theta/params.py
+++ b/git_theta/params.py
@@ -1,5 +1,6 @@
 """Classes for serializing model updates."""
 
+from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 import tensorstore as ts
 import io
@@ -7,57 +8,63 @@ import tarfile
 import posixpath
 
 
-class TensorSerializer:
-    def serialize(self, tensor):
-        raise NotImplementedError
+class TensorSerializer(metaclass=ABCMeta):
+    """Serialize/Deserialize tensors."""
 
-    def deserialize(self, serialized_tensor):
-        raise NotImplementedError
+    @abstractmethod
+    async def serialize(self, tensor):
+        """Convert a tensor to bytes."""
+
+    @abstractmethod
+    async def deserialize(self, serialized_tensor):
+        """Convert bytes to a tensor object."""
 
 
 class TensorStoreSerializer(TensorSerializer):
-    def serialize(self, param):
-        store = ts.open(
+    async def serialize(self, tensor):
+        store = await ts.open(
             {
                 "driver": "zarr",
                 "kvstore": {"driver": "memory"},
-                "metadata": {"shape": param.shape, "dtype": param.dtype.str},
+                "metadata": {"shape": tensor.shape, "dtype": tensor.dtype.str},
                 "create": True,
             },
-        ).result()
-        store.write(param).result()
+        )
+        await store.write(tensor)
         serialized_param = {
-            k.decode("utf-8"): store.kvstore[k] for k in store.kvstore.list().result()
+            k.decode("utf-8"): store.kvstore[k] for k in await store.kvstore.list()
         }
         return serialized_param
 
-    def deserialize(self, serialized_param):
+    async def deserialize(self, serialized_tensor):
         ctx = ts.Context()
-        kvs = ts.KvStore.open("memory://", context=ctx).result()
-        for name, contents in serialized_param.items():
+        kvs = await ts.KvStore.open("memory://", context=ctx)
+        for name, contents in serialized_tensor.items():
             kvs[name] = contents
 
-        store = ts.open(
-            {"driver": "zarr", "kvstore": "memory://"}, context=ctx
-        ).result()
-        param = store.read().result()
+        store = await ts.open({"driver": "zarr", "kvstore": "memory://"}, context=ctx)
+        param = await store.read()
         return param
 
 
-class FileCombiner:
-    def combine(self, files):
-        raise NotImplementedError
+class FileCombiner(metaclass=ABCMeta):
+    """Combine and Split serialized tensors, enables single blob processing for multiple tensors."""
 
+    @abstractmethod
+    def combine(self, files):
+        """Combine multiple byte steams into one."""
+
+    @abstractmethod
     def split(self, file):
-        raise NotImplementedError
+        """Split a combined byte stream into original bytes."""
 
 
 class TarCombiner(FileCombiner):
-    def combine(self, param_files):
+    def combine(self, files):
         tarred_file = io.BytesIO()
         with tarfile.open(fileobj=tarred_file, mode="w") as archive:
-            for param_name, param_files in param_files.items():
-                for filename, file_bytes in param_files.items():
+            for param_name, param_file in files.items():
+                for filename, file_bytes in param_file.items():
                     # N.b. posixpath is used to create the "virtual path" in the tar file to each underlying parameter file
                     # Ensures consistent reading/writing of virtual paths across platforms
                     tarinfo = tarfile.TarInfo(posixpath.join(param_name, filename))
@@ -67,8 +74,8 @@ class TarCombiner(FileCombiner):
         tarred_file.seek(0)
         return tarred_file.read()
 
-    def split(self, tarred_file):
-        file = io.BytesIO(tarred_file)
+    def split(self, file):
+        file = io.BytesIO(file)
         param_files = defaultdict(dict)
         with tarfile.open(fileobj=file, mode="r") as archive:
             for file_in_archive in archive.getnames():
@@ -76,27 +83,37 @@ class TarCombiner(FileCombiner):
                 param_files[param_name][filename] = archive.extractfile(
                     file_in_archive
                 ).read()
-
         return param_files
 
 
-class UpdateSerializer:
+class Serializer(metaclass=ABCMeta):
+    """Serialize/Deserialize parameters, even when represented with multiple tensors."""
+
+    @abstractmethod
+    async def serialize(self, params):
+        """Serialize parameter."""
+
+    @abstractmethod
+    async def deserialize(self, serialized):
+        """Deserialize parameter."""
+
+
+class UpdateSerializer(Serializer):
     def __init__(self, tensor_serializer, file_combiner):
         self.serializer = tensor_serializer
         self.combiner = file_combiner
 
-    def serialize(self, update_params):
+    async def serialize(self, params):
         serialized_params = {
-            name: self.serializer.serialize(param)
-            for name, param in update_params.items()
+            name: await self.serializer.serialize(param)
+            for name, param in params.items()
         }
-        serialized_object = self.combiner.combine(serialized_params)
-        return serialized_object
+        return self.combiner.combine(serialized_params)
 
-    def deserialize(self, serialized_object):
-        serialized_params = self.combiner.split(serialized_object)
+    async def deserialize(self, serialized):
+        serialized_params = self.combiner.split(serialized)
         update_params = {
-            name: self.serializer.deserialize(serialized_param)
+            name: await self.serializer.deserialize(serialized_param)
             for name, serialized_param in serialized_params.items()
         }
         return update_params

--- a/git_theta/updates/__init__.py
+++ b/git_theta/updates/__init__.py
@@ -1,3 +1,3 @@
 """Classes for controlling how parameter updates are made."""
 
-from git_theta.updates.base import Update, get_update_handler
+from git_theta.updates.base import Update, get_update_handler, IncrementalUpdate

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -1,5 +1,6 @@
 """Base class for parameter update plugins."""
 
+from abc import ABCMeta, abstractmethod
 import os
 import sys
 
@@ -9,40 +10,148 @@ else:
     from importlib.metadata import entry_points
 
 import logging
-from typing import Optional
+from typing import Optional, Tuple
+
+import numpy as np
 
 from git_theta import git_utils, utils, params, metadata
 
 
-class Update:
+Parameter = np.ndarray
+
+
+class Update(metaclass=ABCMeta):
     """Base class for parameter update plugins."""
 
-    def read(self, param_metadata):
-        lfs_pointer = param_metadata.lfs_metadata.lfs_pointer
-        serialized_param = git_utils.git_lfs_smudge(lfs_pointer)
-        param = params.get_update_serializer().deserialize(serialized_param)
-        return param
-
-    def get_last_version(self, repo, path, param_keys, param_metadata):
-        last_commit = param_metadata.theta_metadata.last_commit
-        logging.debug(f"Getting data from commit {last_commit}")
-        if last_commit:
-            last_metadata_obj = git_utils.get_file_version(repo, path, last_commit)
-            last_metadata = metadata.Metadata.from_file(last_metadata_obj.data_stream)
-            last_param_metadata = last_metadata.flatten()[param_keys]
-            return last_param_metadata
-        else:
-            raise ValueError("Cannot find previous version for parameters")
+    def __init__(self, serializer: params.Serializer):
+        self.serializer = serializer
 
     @property
-    def name(self):
-        raise NotImplementedError
+    @abstractmethod
+    def name(self) -> str:
+        """The name used to lookup the plug-in."""
 
-    def apply(self, repo, path, param_keys, param_metadata):
-        raise NotImplementedError
+    async def read(self, param_metadata: metadata.ParamMetadata) -> Parameter:
+        """Read in and deserialize a single parameter value based metadata."""
+        lfs_pointer = param_metadata.lfs_metadata.lfs_pointer
+        serialized_param = await git_utils.git_lfs_smudge(lfs_pointer)
+        param = (await self.serializer.deserialize(serialized_param))["parameter"]
+        return param
 
-    def calculate_update(self, repo, path, param_keys, param_metadata, param):
-        raise NotImplementedError
+    @abstractmethod
+    async def write(
+        self, param: Parameter, param_keys: Tuple[str], **kwargs
+    ) -> metadata.LfsMetadata:
+        """Serialize and save a parameter with git-lfs."""
+
+    @abstractmethod
+    async def apply(
+        self, param_metadata: metadata.ParamMetadata, param_keys: Tuple[str], **kwargs
+    ) -> Parameter:
+        """Get the final parameter value, including fetching previous values."""
+
+
+class IncrementalUpdate(Update):
+    """Base class for parameter updates that depend on the previous value."""
+
+    async def get_previous_metadata(
+        self,
+        param_metadata: metadata.ParamMetadata,
+        param_keys: Tuple[str],
+        repo,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        """Get the metadata from the last time this parameter was updated via git."""
+        logging.debug(f"Getting previous metadata for {'/'.join(param_keys)}")
+        logging.debug(f"Current Metadata for {'/'.join(param_keys)}: {param_metadata}")
+        last_commit = param_metadata.theta_metadata.last_commit
+        # TODO: Currently, if the model checkpoint is added during the first commit
+        # then we can't do a sparse update until a second dense update is commited.
+        if not last_commit:
+            raise ValueError(
+                f"Cannot find previous version for parameter {'/'.join(param_keys)}"
+            )
+        logging.debug(
+            f"Getting metadata for {'/'.join(param_keys)} from commit {last_commit}"
+        )
+        last_metadata_obj = git_utils.get_file_version(repo, path, last_commit)
+        last_metadata = metadata.Metadata.from_file(last_metadata_obj.data_stream)
+        last_param_metadata = last_metadata.flatten()[param_keys]
+        logging.debug(
+            f"Previous Metadata for {'/'.join(param_keys)}: {last_param_metadata}"
+        )
+        return last_param_metadata
+
+    async def get_previous_value(
+        self,
+        param_metadata: metadata.ParamMetadata,
+        param_keys: Tuple[str],
+        repo,
+        path: str,
+    ) -> Parameter:
+        """Get the last value for this parameter via git."""
+        logging.debug(f"Getting previous value for {'/'.join(param_keys)}")
+        prev_metadata = await self.get_previous_metadata(
+            param_metadata, param_keys, repo=repo, path=path
+        )
+        # TODO: get_update_serializer returns instantiated objects while the other
+        # getters return classes to be instantiated.
+        prev_serializer = params.get_update_serializer()
+        prev_update = get_update_handler(prev_metadata.theta_metadata.update_type)(
+            prev_serializer
+        )
+        return await prev_update.apply(prev_metadata, param_keys, repo=repo, path=path)
+
+    @abstractmethod
+    async def calculate_update(
+        self, parameter: Parameter, previous_parameter: Parameter
+    ) -> Parameter:
+        """Calculate the update required to go from previous_parameter -> parameter."""
+
+    @abstractmethod
+    async def apply_update(self, update: Parameter, previous: Parameter) -> Parameter:
+        """Apply the update to the previous value to get the new value."""
+
+    async def write_update(self, update: Parameter) -> metadata.LfsMetadata:
+        """Save and serialize (just) the update weights."""
+        serialized_update = await self.serializer.serialize({"parameter": update})
+        lfs_pointer = await git_utils.git_lfs_clean(serialized_update)
+        return metadata.LfsMetadata.from_pointer(lfs_pointer)
+
+    async def write(
+        self,
+        param: Parameter,
+        param_keys,
+        *,
+        param_metadata: metadata.ParamMetadata,
+        repo,
+        path: str,
+        **kwargs,
+    ) -> metadata.LfsMetadata:
+        """Serialize and save a parameter with git-lfs as a delta from the previous value."""
+        logging.debug(f"Writing {self.name} update for {'/'.join(param_keys)}")
+        previous_value = await self.get_previous_value(
+            param_metadata, param_keys, repo=repo, path=path
+        )
+        update_value = await self.calculate_update(param, previous_value)
+        return await self.write_update(update_value)
+
+    async def apply(
+        self,
+        param_metadata: metadata.ParamMetadata,
+        param_keys: Tuple[str],
+        *,
+        repo,
+        path: str,
+        **kwargs,
+    ) -> Parameter:
+        """Get the final parameter value, including fetching previous values."""
+        logging.debug(f"Applying {self.name} update for {'/'.join(param_keys)}")
+        update_value = await self.read(param_metadata)
+        prev_value = await self.get_previous_value(
+            param_metadata, param_keys, repo=repo, path=path
+        )
+        return await self.apply_update(update_value, prev_value)
 
 
 def get_update_handler_name(update_type: Optional[str] = None) -> str:

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -1,28 +1,23 @@
 """A class for handling sparse updates to parameters."""
 
 import logging
-from typing import Optional
-from git_theta.updates import Update, get_update_handler
+from typing import Optional, Any
+from git_theta.updates import IncrementalUpdate
+
+Parameter = Any
 
 
-class SparseUpdate(Update):
+class SparseUpdate(IncrementalUpdate):
     """An update where only some parameters are touched."""
 
     @property
     def name(self):
         return "sparse"
 
-    def calculate_update(self, repo, path, param_keys, param_metadata, param):
-        # TODO: Calculate a real sparse matrix and return the tensors in a dictionary
-        update_handler = get_update_handler(param_metadata.theta_metadata.update_type)()
-        prev_param = update_handler.apply(repo, path, param_keys, param_metadata)
-        return {"update": param - prev_param}
+    async def calculate_update(
+        self, parameter: Parameter, previous_parameter: Parameter
+    ) -> Parameter:
+        return parameter - previous_parameter
 
-    def apply(self, repo, path, param_keys, param_metadata):
-        logging.debug(f"Reading Sparse update for {'/'.join(param_keys)}")
-        sparse_update = self.read(param_metadata)["update"]
-        last_metadata = self.get_last_version(repo, path, param_keys, param_metadata)
-        update_handler = get_update_handler(last_metadata.theta_metadata.update_type)()
-        return sparse_update + update_handler.apply(
-            repo, path, param_keys, last_metadata
-        )
+    async def apply_update(self, update: Parameter, previous: Parameter) -> Parameter:
+        return update + previous

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,10 @@ setup(
         "GitPython",
         "tensorstore >= 0.1.14",
         "file-or-name",
+        "six",
         'importlib_resources; python_version < "3.9.0"',
         'importlib_metadata; python_version < "3.10.0"',
+        'typing_extensions; python_version < "3.8.0"',
     ],
     extras_require={
         "test": ["pytest"],

--- a/tests/params_test.py
+++ b/tests/params_test.py
@@ -1,5 +1,6 @@
 """Tests for params.py"""
 
+import asyncio
 import random
 import pytest
 import numpy as np
@@ -14,8 +15,8 @@ def test_tensorstore_serializer_roundtrip():
     for num_dims in range(1, 6):
         shape = tuple(np.random.randint(1, 20, size=num_dims).tolist())
         t = np.random.rand(*shape)
-        serialized_t = serializer.serialize(t)
-        deserialized_t = serializer.deserialize(serialized_t)
+        serialized_t = asyncio.run(serializer.serialize(t))
+        deserialized_t = asyncio.run(serializer.deserialize(serialized_t))
         np.testing.assert_array_equal(t, deserialized_t)
 
 
@@ -25,8 +26,8 @@ def test_tensorstore_serializer_roundtrip_chunked():
     """
     serializer = params.TensorStoreSerializer()
     t = np.random.rand(5000, 5000)
-    serialized_t = serializer.serialize(t)
-    deserialized_t = serializer.deserialize(serialized_t)
+    serialized_t = asyncio.run(serializer.serialize(t))
+    deserialized_t = asyncio.run(serializer.deserialize(serialized_t))
     np.testing.assert_array_equal(t, deserialized_t)
 
 
@@ -56,8 +57,10 @@ def test_update_serializer_roundtrip():
         "param2": np.random.rand(50, 10, 2),
         "param3": np.random.rand(1000),
     }
-    serialized_update_params = serializer.serialize(update_params)
-    deserialized_update_params = serializer.deserialize(serialized_update_params)
+    serialized_update_params = asyncio.run(serializer.serialize(update_params))
+    deserialized_update_params = asyncio.run(
+        serializer.deserialize(serialized_update_params)
+    )
 
     assert update_params.keys() == deserialized_update_params.keys()
 


### PR DESCRIPTION
This PR updates the our clean and smudge filters to use async to do I/O bound operations (mostly tensorstore serialization and running git-lfs-(clean|smudge)). This is done with an async wrapper of subprocesses that mimics subprocess.run. It also includes tools for running an async function on all the k, v pairs in a dictionary so that they will happen concurrently.

The main async entry point is in the clean and smudge filters where the cleaning (or smuding) function is applied to each leaf in the parameter tree concurrently.

This also updates the Update API a little bit. This update makes async possible (i.e. some methods are converted from `def` to `async def`) and it also makes the API easier for writing new update plugins. Additionally the serializer is now passed to the update class and used internally instead of being used externally. Also things like communication with git-lfs is now done in the write method explicitly instead of being part of the LfsMeatadata creation.

There are still some change wrt to documentation, typing, and the exact Updater API but I wanted to get eyes on it sooner rather than later.