### PR TITLE
Adds a TF Checkpoint plugin.

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Dependencies and Package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .[test,pytorch]
+        python -m pip install .[test,all]
     - name: Run Unit Tests
       run: |
         pytest

--- a/git_theta/checkpoints/__init__.py
+++ b/git_theta/checkpoints/__init__.py
@@ -1,0 +1,7 @@
+"""A module of checkpoint handlers."""
+
+from git_theta.checkpoints.base import (
+    Checkpoint,
+    get_checkpoint_handler,
+    get_checkpoint_handler_name,
+)

--- a/git_theta/checkpoints/base.py
+++ b/git_theta/checkpoints/base.py
@@ -1,4 +1,4 @@
-"""Base class and utilities for different checkout format backends."""
+"""Base class and utilities for different checkpoint format backends."""
 
 from abc import ABCMeta, abstractmethod
 import os

--- a/git_theta/checkpoints/base.py
+++ b/git_theta/checkpoints/base.py
@@ -1,8 +1,7 @@
-"""Backends for different checkpoint formats."""
+"""Base class and utilities for different checkout format backends."""
 
+from abc import ABCMeta, abstractmethod
 import os
-import json
-import io
 import sys
 from typing import Optional
 import numpy as np
@@ -12,18 +11,16 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
-from file_or_name import file_or_name
-
-from . import utils
+from git_theta import utils
 
 
-class Checkpoint(dict):
+class Checkpoint(dict, metaclass=ABCMeta):
     """Abstract base class for wrapping checkpoint formats."""
 
     @property
+    @abstractmethod
     def name(self):
         """The name of this checkpoint handler, can be used to lookup the plugin."""
-        raise NotImplementedError
 
     @classmethod
     def from_file(cls, checkpoint_path):
@@ -37,6 +34,7 @@ class Checkpoint(dict):
         return cls(cls.load(checkpoint_path))
 
     @classmethod
+    @abstractmethod
     def load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
 
@@ -48,11 +46,11 @@ class Checkpoint(dict):
         Returns
         -------
         model_dict : dict
-            Dictionary mapping parameter names to parameter values. Parameters
+            Dictionary mapping parameter names to parameter values.  Parameters
             should be numpy arrays.
         """
-        raise NotImplementedError
 
+    @abstractmethod
     def save(self, checkpoint_path):
         """Load a checkpoint into a dict format.
 
@@ -61,69 +59,12 @@ class Checkpoint(dict):
         checkpoint_path : str or file-like object
             Path to write out the checkpoint file to
         """
-        raise NotImplementedError
 
     def flatten(self):
         return utils.flatten(self, is_leaf=lambda v: isinstance(v, np.ndarray))
 
     def unflatten(self):
         return utils.unflatten(self)
-
-
-class PickledDictCheckpoint(Checkpoint):
-    """Class for wrapping picked dict checkpoints, commonly used with PyTorch."""
-
-    @property
-    def name(self):
-        return "pickled-dict"
-
-    @classmethod
-    @file_or_name(checkpoint_path="rb")
-    def load(cls, checkpoint_path):
-        """Load a checkpoint into a dict format.
-
-        Parameters
-        ----------
-        checkpoint_path : str or file-like object
-            Path to a checkpoint file
-
-        Returns
-        -------
-        model_dict : dict
-            Dictionary mapping parameter names to parameter values. Parameters
-            should be numpy arrays.
-        """
-        # TODO(bdlester): Once multiple checkpoint types are supported and
-        # this checkpoint object is moved to its own module, move this import
-        # back to toplevel. Currently it is inside the object methods to allow
-        # for optional framework installs.
-        import torch
-
-        model_dict = torch.load(io.BytesIO(checkpoint_path.read()))
-        if not isinstance(model_dict, dict):
-            raise ValueError("Supplied PyTorch checkpoint must be a dict.")
-        if not all(isinstance(k, str) for k in model_dict.keys()):
-            raise ValueError("All PyTorch checkpoint keys must be strings.")
-        if not all(isinstance(v, torch.Tensor) for v in model_dict.values()):
-            raise ValueError("All PyTorch checkpoint values must be tensors.")
-        return {k: v.cpu().numpy() for k, v in model_dict.items()}
-
-    def save(self, checkpoint_path):
-        """Load a checkpoint into a dict format.
-
-        Parameters
-        ----------
-        checkpoint_path : str or file-like object
-            Path to write out the checkpoint file to
-        """
-        # TODO(bdlester): Once multiple checkpoint types are supported and
-        # this checkpoint object is moved to its own module, move this import
-        # back to toplevel. Currently it is inside the object methods to allow
-        # for optional framework installs.
-        import torch
-
-        checkpoint_dict = {k: torch.as_tensor(v) for k, v in self.items()}
-        torch.save(checkpoint_dict, checkpoint_path)
 
 
 def get_checkpoint_handler_name(checkpoint_type: Optional[str] = None) -> str:
@@ -157,7 +98,9 @@ def get_checkpoint_handler_name(checkpoint_type: Optional[str] = None) -> str:
 def get_checkpoint_handler(checkpoint_type: Optional[str] = None) -> Checkpoint:
     """Get the checkpoint handler either by name or from an environment variable.
 
-    Gets the checkpoint handler either for the `checkpoint_type` argument or `$GIT_THETA_CHECKPOINT_TYPE` environment variable.
+    Gets the checkpoint handler either for the `checkpoint_type` argument or
+    `$GIT_THETA_CHECKPOINT_TYPE` environment variable.
+
     Defaults to pytorch when neither are defined.
 
     Parameters
@@ -168,8 +111,8 @@ def get_checkpoint_handler(checkpoint_type: Optional[str] = None) -> Checkpoint:
     Returns
     -------
     Checkpoint
-        The checkpoint handler (usually an instance of `git_theta.checkpoints.Checkpoint`). Returned handler may be defined in a user installed
-        plugin.
+        The checkpoint handler (usually an instance of `git_theta.checkpoints.Checkpoint`).
+        Returned handler may be defined in a user installed plugin.
     """
     checkpoint_type = get_checkpoint_handler_name(checkpoint_type)
     discovered_plugins = entry_points(group="git_theta.plugins.checkpoints")

--- a/git_theta/checkpoints/pickled_dict_checkpoint.py
+++ b/git_theta/checkpoints/pickled_dict_checkpoint.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+
+import io
+import torch
+from git_theta.checkpoints import Checkpoint
+
+
+class PickledDictCheckpoint(Checkpoint):
+    """Class for wrapping picked dict checkpoints, commonly used with PyTorch."""
+
+    @classmethod
+    def load(cls, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to a checkpoint file
+
+        Returns
+        -------
+        model_dict : dict
+            Dictionary mapping parameter names to parameter values
+        """
+        if isinstance(checkpoint_path, io.IOBase):
+            checkpoint_path = io.BytesIO(checkpoint_path.read())
+
+        model_dict = torch.load(checkpoint_path)
+        if not isinstance(model_dict, dict):
+            raise ValueError("Supplied PyTorch checkpoint must be a dict.")
+        if not all(isinstance(k, str) for k in model_dict.keys()):
+            raise ValueError("All PyTorch checkpoint keys must be strings.")
+        if not all(isinstance(v, torch.Tensor) for v in model_dict.values()):
+            raise ValueError("All PyTorch checkpoint values must be tensors.")
+        return {k: v.cpu().numpy() for k, v in model_dict.items()}
+
+    def save(self, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to write out the checkpoint file to
+        """
+        checkpoint_dict = {k: torch.as_tensor(v) for k, v in self.items()}
+        torch.save(checkpoint_dict, checkpoint_path)

--- a/git_theta/checkpoints/tensorflow_checkpoint.py
+++ b/git_theta/checkpoints/tensorflow_checkpoint.py
@@ -1,0 +1,74 @@
+"""A Checkpoint backend for tensorflow models."""
+
+
+import numpy as np
+import tensorflow as tf
+from git_theta.checkpoints import Checkpoint
+from git_theta import utils
+
+
+class DynamicNetwork(tf.keras.Model):
+    """A keras model that can dynamically build itself from a map of params for tf saving."""
+
+    def __init__(self, params):
+        super().__init__()
+        for name, param in params.items():
+            # Convert numpy to tf.Variable so it will be saved.
+            if isinstance(param, np.ndarray):
+                param = tf.Variable(param, name=name)
+            # Converted nested models into nested networks.
+            elif isinstance(param, dict):
+                param = DynamicNetwork(param)
+            # Save the variable (or sub-model) to an attribute so it will get tracked.
+            self.__setattr__(name, param)
+
+
+class TensorFlowCheckpoint(Checkpoint):
+    """Process a TensorFlow checkpoint via `tf.keras.Model.save_weights`. (no computation graph included)."""
+
+    VALUE_STRING = ".ATTRIBUTES/VARIABLE_VALUE"
+
+    @property
+    def name(self):
+        return "tensorflow-checkpoint"
+
+    @staticmethod
+    def is_parameter(param_name: str) -> bool:
+        return param_name.endswith(TensorFlowCheckpoint.VALUE_STRING)
+
+    @staticmethod
+    def normalize_name(param_name: str) -> str:
+        param_name = utils.remove_suffix(param_name, TensorFlowCheckpoint.VALUE_STRING)
+        param_name = utils.remove_suffix(param_name, "/")
+        return param_name
+
+    @classmethod
+    def load(cls, checkpoint_path: str):
+        ckpt_read = tf.train.load_checkpoint(checkpoint_path)
+        params = {}
+        for param_name in ckpt_read.get_variable_to_shape_map():
+            if not TensorFlowCheckpoint.is_parameter(param_name):
+                continue
+            simple_name = TensorFlowCheckpoint.normalize_name(param_name)
+            params[tuple(simple_name.split("/"))] = ckpt_read.get_tensor(param_name)
+        return utils.unflatten(params)
+
+    def save(self, checkpoint_path: str):
+        model = DynamicNetwork(self)
+        model.save_weights(checkpoint_path)
+
+
+# TODO
+class TensorFlowSavedModel(Checkpoint):
+    """Process a TensorFlow SavedModel (computation graph included)."""
+
+    @property
+    def name(self):
+        return "tensorflow-savedmodel"
+
+    @classmethod
+    def load(cls, checkpoint_path: str):
+        raise ValueError("Sorry, SavedModel support is a work in progress.")
+
+    def save(self, checkpoint_path: str):
+        raise ValueError("Sorry, SavedModel support is a work in progress.")

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -1,6 +1,5 @@
 """Utilities for git theta"""
 
-
 import os
 from typing import Dict, Any, Tuple, Union, Callable
 import re
@@ -92,3 +91,10 @@ def is_valid_commit_hash(commit_hash: str) -> bool:
         Whether this commit hash is valid
     """
     return re.match("^[0-9a-f]{40}$", commit_hash) is not None
+
+
+def remove_suffix(s: str, suffix: str) -> str:
+    """Remove suffix matching copy semantics of methods in later pythons."""
+    if suffix and s.endswith(suffix):
+        return s[: -len(suffix)]
+    return s[:]

--- a/setup.py
+++ b/setup.py
@@ -72,13 +72,20 @@ setup(
         "test": ["pytest"],
         "pytorch": ["torch"],
         "tensorflow": ["tensorflow"],
-        # TODO: Add tensorflow to the all target once tf checkpoint support is added.
-        "all": ["torch"],
+        # TODO: Is there a way for all to be the concat of the list of others
+        # instead of making a new list? In case some framework needs multiple
+        # libraries installed?
+        "all": ["torch", "tensorflow"],
     },
     entry_points={
         "git_theta.plugins.checkpoints": [
             "pytorch = git_theta.checkpoints:PickledDictCheckpoint",
             "pickled-dict = git_theta.checkpoints:PickledDictCheckpoint",
+            "tf = git_theta.checkpoints.tensorflow_checkpoint:TensorFlowCheckpoint",
+            "tensorflow = git_theta.checkpoints.tensorflow_checkpoint:TensorFlowCheckpoint",
+            "tensorflow-checkpoint = git_theta.checkpoints.tensorflow_checkpoint:TensorFlowCheckpoint",
+            "tf-savedmodel = git_theta.checkpoints.tensorflow_checkpoint:TensorFlowSavedModel",
+            "tensorflow-savedmodel = git_theta.checkpoints.tensorflow_checkpoint:TensorFlowSavedModel",
         ],
         "git_theta.plugins.updates": [
             "dense = git_theta.updates.dense:DenseUpdate",

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -67,6 +67,8 @@ def test_get_checkpoint_handler_name_default2(empty_env_var):
     assert name == "pytorch"
 
 
+# TODO: Move this (and other pytorch checkpoint tests) to new file. Remove the
+# importorskip too.
 def test_get_checkpoint_handler_pytorch(no_env_var):
     """Check that checkpoint_handler type is correct for when checkpoint_handler name resolves to pytorch"""
 

--- a/tests/checkpoints_test.py
+++ b/tests/checkpoints_test.py
@@ -5,6 +5,8 @@ import pytest
 
 from git_theta import checkpoints, utils
 
+pytest.importorskip("pytorch")
+
 
 @pytest.fixture
 def env_var():
@@ -69,4 +71,4 @@ def test_get_checkpoint_handler_pytorch(no_env_var):
     """Check that checkpoint_handler type is correct for when checkpoint_handler name resolves to pytorch"""
 
     out = checkpoints.get_checkpoint_handler("pytorch")
-    assert out == checkpoints.PickledDictCheckpoint
+    assert out == checkpoints.pickled_dict_checkpoint.PickledDictCheckpoint

--- a/tests/tensorflow_checkpoint_test.py
+++ b/tests/tensorflow_checkpoint_test.py
@@ -1,0 +1,98 @@
+"""Tensorflow checkpoint tests."""
+
+import os
+from unittest import mock
+import tempfile
+import pytest
+import numpy as np
+
+# Skip all these tests if tensorflow is not installed
+tf = pytest.importorskip("tensorflow")
+
+from git_theta import checkpoints
+from git_theta.checkpoints import tensorflow_checkpoint
+
+
+INPUT_SIZE = 10
+
+
+@pytest.fixture(autouse=True)
+def hide_cuda():
+    with mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": ""}):
+        yield
+
+
+class InnerLayer(tf.keras.layers.Layer):
+    def __init__(self):
+        super().__init__(name="inner")
+        self.dense = tf.keras.layers.Dense(5)
+        # Add a non-trainable parameter for completeness.
+        self.scale = tf.Variable(12.0, name="scalar", trainable=False)
+
+    def call(self, x):
+        return self.dense(x) * self.scale
+
+
+class DemoModel(tf.keras.Model):
+    def __init__(self):
+        super().__init__()
+        self.inner = InnerLayer()
+        self.logits = tf.keras.layers.Dense(2, name="logits")
+
+    def call(self, x):
+        return self.logits(self.inner(x))
+
+
+def make_fake_model():
+    dm = DemoModel()
+    dm(np.zeros((1, INPUT_SIZE)))
+    return dm
+
+
+@pytest.fixture
+def fake_model():
+    return make_fake_model()
+
+
+def test_round_trip(fake_model):
+    with tempfile.NamedTemporaryFile() as f:
+        # Make a checkpoint via tensorflow
+        fake_model.save_weights(f.name)
+        # Load the Checkpoint
+        ckpt = tensorflow_checkpoint.TensorFlowCheckpoint.from_file(f.name)
+        with tempfile.NamedTemporaryFile() as f2:
+            # Use the git-theta save to create a new checkpoint
+            ckpt.save(f2.name)
+            # Load a model from they checkpoint we just saved
+            loaded_model = make_fake_model()
+            loaded_model.load_weights(f2.name)
+    for og, new in zip(fake_model.variables, loaded_model.variables):
+        np.testing.assert_allclose(og.numpy(), new.numpy())
+
+
+def test_round_trip_with_modifications(fake_model):
+    with tempfile.NamedTemporaryFile() as f:
+        # Make a checkpoint via tensorflow
+        fake_model.save_weights(f.name)
+        # Load the Checkpoint
+        ckpt = tensorflow_checkpoint.TensorFlowCheckpoint.from_file(f.name)
+        # Update value
+        ckpt["logits"]["bias"] = np.ones_like(ckpt["logits"]["bias"])
+        with tempfile.NamedTemporaryFile() as f2:
+            # Use the git-theta save to create a new checkpoint
+            ckpt.save(f2.name)
+            # Load a model from they checkpoint we just saved
+            loaded_model = make_fake_model()
+            loaded_model.load_weights(f2.name)
+    for og, new in zip(fake_model.variables, loaded_model.variables):
+        # Check that the updated value is loaded.
+        if "logits" in new.name and "bias" in new.name:
+            new_numpy = new.numpy()
+            np.testing.assert_allclose(new_numpy, np.ones(*new_numpy.shape))
+        else:
+            np.testing.assert_allclose(og.numpy(), new.numpy())
+
+
+def test_get_checkpoint_handler_tensorflow():
+    out = checkpoints.get_checkpoint_handler("tensorflow-checkpoint")
+    assert out == tensorflow_checkpoint.TensorFlowCheckpoint

--- a/tests/tensorflow_checkpoint_test.py
+++ b/tests/tensorflow_checkpoint_test.py
@@ -67,7 +67,7 @@ def test_round_trip(fake_model):
             loaded_model = make_fake_model()
             loaded_model.load_weights(f2.name)
     for og, new in zip(fake_model.variables, loaded_model.variables):
-        np.testing.assert_allclose(og.numpy(), new.numpy())
+        np.testing.assert_array_equal(og.numpy(), new.numpy())
 
 
 def test_round_trip_with_modifications(fake_model):


### PR DESCRIPTION
This PR adds a Tensorflow checkpoint plugin based on the checkpoint format output from `tensorflow.keras.Model.save_weights`. This format does not include the computational graph.

This PR includes tests for git-theta to read and write a tf checkpoint and ensure that the values are correct (one test leaves all values unchanged and another makes modifications).

It also leaves a skeleton for the tensorflow SavedModel checkpoint format but that is not implemented.

It also updates some of the installation so that not all frameworks are needed at once and it ensure that tests are only run of the required framework is installed.

Closes https://github.com/r-three/git-theta/issues/85
Closes https://github.com/r-three/git-theta/issues/79