### PR TITLE
Add a Low-Rank Update type.

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -55,7 +55,7 @@ def parse_args():
     add_parser = subparsers.add_parser("add", help="add command used to stage files.")
     add_parser.add_argument(
         "--update-type",
-        choices=["dense", "sparse"],
+        choices=["dense", "sparse", "low-rank"],
         help="Type of update being applied",
     )
     add_parser.set_defaults(func=add)

--- a/git_theta/updates/low_rank.py
+++ b/git_theta/updates/low_rank.py
@@ -1,0 +1,46 @@
+"""An update type where the update is stored as 2 low-rank matrices."""
+
+
+import logging
+from typing import Any, Optional
+import numpy as np
+from git_theta.updates import IncrementalUpdate
+
+Parameter = Any
+
+
+class LowRankUpdate(IncrementalUpdate):
+    """An update make for 2 low rank matrices."""
+
+    # TODO: Make these configuration options easy set.
+    def __init__(
+        self, *args, K: Optional[int] = None, threshold: float = 1e-11, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.K = K
+        self.threshold = threshold
+
+    @property
+    def name(self):
+        return "low-rank"
+
+    async def calculate_update(
+        self, parameter: Parameter, previous_parameter: Parameter
+    ) -> Parameter:
+        update = parameter - previous_parameter
+        if update.ndim < 2:
+            return update
+        logging.info("Inferring low-rank update based on SVD")
+        u, s, vh = np.linalg.svd(update, full_matrices=False)
+        if self.K is not None:
+            k = self.K
+            logging.info(f"Low Rank Update configured to have a rank of {k}")
+        else:
+            k = np.sum(s > self.threshold)
+            logging.info(f"Low Rank Update inferred to have a rank of {k}")
+        return {"R": u[:, :k], "C": (np.diag(s[:k]) @ vh[:k, :])}
+
+    async def apply_update(self, update: Parameter, previous: Parameter) -> Parameter:
+        if not isinstance(update, dict):
+            return update + previous
+        return update["R"] @ update["C"] + previous

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         "git_theta.plugins.updates": [
             "dense = git_theta.updates.dense:DenseUpdate",
             "sparse = git_theta.updates.sparse:SparseUpdate",
+            "low-rank = git_theta.updates.low_rank:LowRankUpdate",
         ],
     },
 )

--- a/tests/updates/low_rank_test.py
+++ b/tests/updates/low_rank_test.py
@@ -1,0 +1,63 @@
+"""Tests for our low Rank Update."""
+
+
+import numpy as np
+import pytest
+from git_theta import async_utils
+from git_theta import params
+from git_theta.updates import low_rank
+
+
+K = 20
+INPUT_SIZE = 1024
+OUTPUT_SIZE = 1024
+TRIALS = 50
+
+
+@pytest.fixture
+def updater():
+    return low_rank.LowRankUpdate(params.get_update_serializer())
+
+
+def test_low_rank_update_rank_inference(updater):
+
+    for _ in range(TRIALS):
+        parameter = np.random.randn(INPUT_SIZE, OUTPUT_SIZE)
+        R = np.random.randn(INPUT_SIZE, K)
+        C = np.random.randn(K, OUTPUT_SIZE)
+        updated_parameter = R @ C + parameter
+
+        update = async_utils.run(updater.calculate_update(updated_parameter, parameter))
+        assert update["R"].shape == R.shape
+        assert update["C"].shape == C.shape
+
+
+@pytest.mark.xfail(strict=False)
+def test_low_rank_update_application(updater):
+
+    for _ in range(TRIALS):
+        parameter = np.random.randn(INPUT_SIZE, OUTPUT_SIZE)
+        R = np.random.randn(INPUT_SIZE, K)
+        C = np.random.randn(K, OUTPUT_SIZE)
+        updated_parameter = R @ C + parameter
+
+        update = async_utils.run(updater.calculate_update(updated_parameter, parameter))
+        result = async_utils.run(updater.apply_update(update, parameter))
+
+        np.testing.assert_allclose(result, updated_parameter, rtol=1e-6)
+
+
+def test_low_rank_update_application_1d(updater):
+    parameter = np.random.randn(INPUT_SIZE)
+    update = np.random.randn(*parameter.shape)
+
+    updated_parameter = update + parameter
+
+    calculated_update = async_utils.run(
+        updater.calculate_update(updated_parameter, parameter)
+    )
+    calculated_result = async_utils.run(
+        updater.apply_update(calculated_update, parameter)
+    )
+
+    np.testing.assert_allclose(calculated_result, updated_parameter)


### PR DESCRIPTION
This PR adds an implementation of Low Rank Updates. In this setting, the parts of the low rank update are inferred from the difference between the previous and current parameter using SVD.

This includes tests that verify that rank inference based on the singular values and also that the application of update results in a numpy allclose result.

Closes https://github.com/r-three/git-theta/issues/108