### PR TITLE
Fix bug because sparse tensor shape is a tuple.

### DIFF
--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -26,7 +26,7 @@ class SparseUpdate(IncrementalUpdate):
             "data": update.data,
             "indices": update.indices,
             "indptr": update.indptr,
-            "shape": parameter.shape,
+            "shape": np.array(parameter.shape),
         }
 
     async def apply_update(self, update: Parameter, previous: Parameter) -> Parameter:


### PR DESCRIPTION
The TensorStore serializer only wants np.arrays (it calls methods on them). When it tried to call this on the shape tuple it failed.