### PR TITLE
Hotfix for Incremental Updates

### DIFF
--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -78,7 +78,7 @@ def clean(args):
         lfs_metadata = await update_handler.write(
             new_param,
             param_keys,
-            param_metadata=param_metadata,
+            prev_metadata=param_metadata,
             repo=repo,
             path=args.file,
         )

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -91,16 +91,13 @@ class IncrementalUpdate(Update):
     ) -> Parameter:
         """Get the last value for this parameter via git."""
         logging.debug(f"Getting previous value for {'/'.join(param_keys)}")
-        prev_metadata = await self.get_previous_metadata(
-            param_metadata, param_keys, repo=repo, path=path
-        )
         # TODO: get_update_serializer returns instantiated objects while the other
         # getters return classes to be instantiated.
         prev_serializer = params.get_update_serializer()
-        prev_update = get_update_handler(prev_metadata.theta_metadata.update_type)(
+        prev_update = get_update_handler(param_metadata.theta_metadata.update_type)(
             prev_serializer
         )
-        return await prev_update.apply(prev_metadata, param_keys, repo=repo, path=path)
+        return await prev_update.apply(param_metadata, param_keys, repo=repo, path=path)
 
     @abstractmethod
     async def calculate_update(
@@ -120,12 +117,17 @@ class IncrementalUpdate(Update):
         lfs_pointer = await git_utils.git_lfs_clean(serialized_update)
         return metadata.LfsMetadata.from_pointer(lfs_pointer)
 
+    # TODO: Revisit what the metadata a write takes, right now it gets the full
+    # metadata of the previous parameter value but only uses the update type. If
+    # we do call get_previous_metadata on it, like we do in apply, the result is
+    # that a parameter value is skipped and we calculate the incremental update
+    # from 2 steps back, which can be a foot-gun.
     async def write(
         self,
         param: Parameter,
         param_keys,
         *,
-        param_metadata: metadata.ParamMetadata,
+        prev_metadata: metadata.ParamMetadata,
         repo,
         path: str,
         **kwargs,
@@ -133,7 +135,7 @@ class IncrementalUpdate(Update):
         """Serialize and save a parameter with git-lfs as a delta from the previous value."""
         logging.debug(f"Writing {self.name} update for {'/'.join(param_keys)}")
         previous_value = await self.get_previous_value(
-            param_metadata, param_keys, repo=repo, path=path
+            prev_metadata, param_keys, repo=repo, path=path
         )
         update_value = await self.calculate_update(param, previous_value)
         return await self.write_update(update_value)
@@ -150,8 +152,13 @@ class IncrementalUpdate(Update):
         """Get the final parameter value, including fetching previous values."""
         logging.debug(f"Applying {self.name} update for {'/'.join(param_keys)}")
         update_value = await self.read(param_metadata)
-        prev_value = await self.get_previous_value(
+        # param_metadata is the metadata for the parameter as it is *at this
+        # commit*.
+        prev_metadata = await self.get_previous_metadata(
             param_metadata, param_keys, repo=repo, path=path
+        )
+        prev_value = await self.get_previous_value(
+            prev_metadata, param_keys, repo=repo, path=path
         )
         return await self.apply_update(update_value, prev_value)
 


### PR DESCRIPTION
In the original multi-pointer implementation, the writing of the parameter was done as a multi-step process in the clean filter. When I folded that functionality into the IncrementalUpdate class I made a mistake with the semantics of the `param_metadata` parameter. During a clean filter, `param` is the parameter value in the checkpoint right **now**, while `param_metadata` is the metadata from the model that **currently checked in**. This means that when we "get the previous value" we actually want the value that this `param_metadata` represents, as it is previous to the value that is in the checkpoint right now.

Contrast this with the `apply` method. In this case, there is no `param` vaule, instead there is just `param_metadata` and we want to get the value of the parameter for that metadata. This means that for an Incremental Update apply does need to fetch the previous values.

In trying to share as much code as I could, I ended up folding the get previous metadata functionality into a get previous value method. This results in write doing a double look up, skipping the true previous value.

This PR fixes this change by moving the previous metadata fetching out of the value fetching and only calling it during apply. It also renames the parameter of the `write` method to `prev_metadata` so it is clearer going forward.