### PR TITLE
Git-Theta custom merge tool

### DIFF
--- a/bin/git-theta
+++ b/bin/git-theta
@@ -125,6 +125,8 @@ def install(args):
     config_writer.set_value('filter "theta"', "clean", "git-theta-filter clean %f")
     config_writer.set_value('filter "theta"', "smudge", "git-theta-filter smudge %f")
     config_writer.set_value('filter "theta"', "required", "true")
+    config_writer.set_value('merge "theta"', "name", "Merge Models with Git-Theta")
+    config_writer.set_value('merge "theta"', "driver", "git-theta-merge %O %A %B %P")
     config_writer.release()
 
 

--- a/bin/git-theta-merge
+++ b/bin/git-theta-merge
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+
+
+import argparse
+import itertools
+import logging
+import sys
+import functools
+from typing import Optional, Dict, Any, List, FrozenSet, Union
+from prompt_toolkit import PromptSession, print_formatted_text
+from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.validation import Validator, ValidationError
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.completion import WordCompleter
+from git_theta import metadata
+from git_theta import merges
+from git_theta.utils import DiffState, Trie, TEXT_STYLE
+
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    # Log to a file for clean/smudge as they don't appear on the console when called via git.
+    filename="/tmp/git-theta.log",
+    format="git-theta-merge: [%(asctime)s] %(levelname)s - %(message)s",
+)
+
+
+def infer_state(
+    ancestor: Optional[metadata.ParamMetadata],
+    current: Optional[metadata.ParamMetadata],
+    other: Optional[metadata.ParamMetadata],
+) -> DiffState:
+    """Convert differences between each branch into a semantic difference."""
+    if ancestor == current == other:
+        return DiffState.EQUAL
+    if ancestor == other and current != ancestor:
+        if ancestor is None:
+            return DiffState.ADDED_A
+        if current is None:
+            return DiffState.DELETED_A
+        return DiffState.CHANGED_A
+    if ancestor == current and current != other:
+        if ancestor is None:
+            return DiffState.ADDED_B
+        if current is None:
+            return DiffState.DELETED_B
+        return DiffState.CHANGED_B
+    if ancestor is None:
+        return DiffState.DELETED_B
+    return DiffState.CHANGED_BOTH
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="git-theta merge program")
+    parser.add_argument("ancestor")  # %O
+    parser.add_argument("current")  # %A
+    parser.add_argument("other")  # %B
+    parser.add_argument("path")  # %P
+    args = parser.parse_args()
+    return args
+
+
+class CommandValidator(Validator):
+    """Only allow valid commands."""
+
+    def __init__(self, avail: Dict[str, Any], prefixes: Trie, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.avail = avail
+        self.prefixes = prefixes
+
+    def validate(self, document):
+        text = document.text
+        # The `in` check is done with the dictionary of kb short cuts -> action
+        # instead of the trie because it is O(1) % cost of hashing while an `in`
+        # operation on a trie is O(n)
+        if text and text not in self.avail:
+            # The trie lets us validate that the user is typing something that
+            # could be a value in the auto complete list.
+            if self.prefixes.prefix(text):
+                # Raise this error to stop the user from hitting enter but don't
+                # show that anything is actually wrong.
+                raise ValidationError(message="", cursor_position=len(text))
+            raise ValidationError(
+                message="This input is not an allowed action.",
+                cursor_position=len(text),
+            )
+
+
+class FilteredAutoSuggestFromHistory(AutoSuggestFromHistory):
+    """AutoSuggest that is aware of current allowable actions."""
+
+    def __init__(self, *args, valid_suggestions, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.valid_suggestions = valid_suggestions
+
+    def get_suggestion(self, buffer, document):
+        suggestion = super().get_suggestion(buffer, document)
+        # Suggestions are populated from history, but make sure we don't
+        # populate with a command that was valid in the past but not now.
+        if suggestion:
+            full_action = f"{document.text}{suggestion.text}"
+            suggestion = suggestion if full_action in self.valid_suggestions else None
+        return suggestion
+
+
+def make_short_cuts(
+    handlers: Dict[str, merges.Merge], reserved: FrozenSet[str] = frozenset({"q"})
+):
+    """Convert the loaded plugin to a map from action triggering string to handler.
+
+    Note:
+        Each handler can request a specific string to use for selection via the
+        SHORT_CUT class attribute, if that string is already in-use then the
+        next value from an incrementing series of numbers is used as the
+        section string.
+
+        Plug-ins are processed alphabetically based on the name used to register
+        them. If these names are eventually abused to ensure some plugin gets a
+        specific action string (i.e. it is named AAAAAActualName) we may want to
+        add a display name attribute.
+    """
+    short_cuts = {}
+    action = 1
+    for _, handler in sorted(handlers.items()):
+        # Warn if there is a plug-in using a reserved action keyword.
+        # A = short_cut is reserved
+        # B = short_cut is free
+        if handler.SHORT_CUT in reserved:
+            # Triggers for [A ∧ B, A ∧ ¬B]
+            logging.warning(
+                f"Merge Plug-in {handler.NAME} requested short-cut"
+                f" {handler.SHORT_CUT} which is reserved."
+            )
+        # If their requested shortcut is available, give it to them.
+        elif handler.SHORT_CUT not in short_cuts:
+            # elif makes sure this only happens if the short cut is not in use and
+            # it is not in the reserved set.
+            # Triggers for [¬A ∧ B]
+            short_cuts[handler.SHORT_CUT] = handler
+            continue
+        # Otherwise give them the next number.
+        # Triggers for [A ∧ B, A ∧ ¬B, ¬A ∧ ¬B]
+        short_cuts[action] = handler
+        action += 1
+    return short_cuts
+
+
+def filter_actions(
+    state: DiffState, actions: Dict[str, merges.Merge]
+) -> Dict[str, merges.Merge]:
+    """Filter out actions that are not applicable in this state."""
+    return {
+        kb: action
+        for kb, action in actions.items()
+        if state not in action.INACTIVE_STATES
+    }
+
+
+def build_menu(
+    actions: Dict[str, Union[str, merges.Merge]], indent: int = 2
+) -> List[str]:
+    """Convert the mapping of strings to actions into a menu."""
+    menu = []
+    # Format action strings so they all end at the same place.
+    longest_kb = max(len(kb) for kb in actions)
+    for kb, action in actions.items():
+        menu.append(f"{kb:>{longest_kb}})  {action}")
+    # Add a small indent to each action.
+    menu = [f"{'':>{indent}}{m}" for m in menu]
+    return menu
+
+
+def merge(args):
+    """git-theta checkpoint aware merging."""
+    print_formatted_text(
+        HTML(f"<b>Fixing Merge Conflicts in {TEXT_STYLE.format_model(args.path)}</b>")
+    )
+    logging.debug(f"Running merge driver on {args.path}")
+    # Load the `cleaned` metadata file for the ancestor commit.
+    ancestor = metadata.Metadata.from_file(args.ancestor)
+    ancestor = ancestor.flatten()
+    # Load the `cleaned` metadata file for commit on our branch.
+    current = metadata.Metadata.from_file(args.current)
+    current = current.flatten()
+    # Load the `cleaned` metadata file for commit on the other branch.
+    other = metadata.Metadata.from_file(args.other)
+    other = other.flatten()
+    # Collect the list of all parameter names. NB: Names are collected from all
+    # models as they may have been deleted/added on different branches.
+    all_params = sorted(
+        list(set(itertools.chain(ancestor.keys(), current.keys(), other.keys())))
+    )
+    # Load all merge handlers and assign each one a kb shortcut.
+    handlers = merges.all_merge_handlers()
+    short_cuts = make_short_cuts(handlers)
+
+    # A place to aggregate metadata for the merged model.
+    merged_model = {}
+    # A place to store loaded parameters to enable reuse/caching. Currently
+    # modified in-place :(
+    partial_current = {}
+    partial_other = {}
+    partial_ancestor = {}
+    # Create a `prompt_toolkit` session so we can auto suggest action based on
+    # history i.e. if they keep taking the other branches change, suggest that
+    # for the next parameter.
+    session = PromptSession()
+    for param_name in all_params:
+        # Get each the parameter metadata from each model.
+        ancestor_param = ancestor.get(param_name)
+        current_param = current.get(param_name)
+        other_param = other.get(param_name)
+        # The parameter name with / for scoping.
+        name = "/".join(param_name)
+
+        # What happened to the parameter across branches?
+        state = infer_state(ancestor_param, current_param, other_param)
+
+        # Changes that don't need human action to be resolved.
+        # If the parameter is unchanged between all models just use it.
+        if state is DiffState.EQUAL:
+            logging.debug(
+                f"Parameter {name} was unchanged by either branch. "
+                "Keeping the value the same going forward."
+            )
+            merged_model[param_name] = ancestor_param
+            continue
+        if state is DiffState.DELETED_BOTH:
+            logging.debug(
+                f"Parameter {name} was deleted on both branches. "
+                "Removing from the merged result."
+            )
+            continue
+
+        # Enumerate the actions you can take based on the state of the params.
+        available_actions = filter_actions(state, short_cuts)
+        # Add a quit action.
+        available_actions["q"] = "quit"
+        # A Trie for prefix loop up of available action commands.
+        available_prefixes = Trie.from_iterable(available_actions)
+
+        # Build an action menu.
+        text = [
+            # What parameter we are working with and what happened to it.
+            f"<b>{TEXT_STYLE.format_param(name)}</b>: {state.value}",
+            "Actions:",
+        ]
+        # Add allowed actions.
+        text.extend(build_menu(available_actions))
+        # Input prompt.
+        text.append("𝜃 ")
+        text = HTML("\n".join(text))
+        # An info box at the bottom of the cli, helps remind users of the context
+        # they are working on.
+        context = HTML(
+            f'Merging parameter: <b><style bg="{TEXT_STYLE.param}">{name}</style></b>'
+            f' in model <i><style bg="{TEXT_STYLE.model}">{args.path}</style></i>'
+        )
+
+        # User action selection.
+        action = session.prompt(
+            # Show the menu
+            text,
+            # Show the merge context
+            bottom_toolbar=context,
+            # Validate that their input is either a valid action or is the
+            # prefix of a valid action. This lets us alert early if their input
+            # is not in the autocomplete menu.
+            validator=CommandValidator(available_actions, available_prefixes),
+            # Suggest completions they have used before, accept with ->
+            auto_suggest=FilteredAutoSuggestFromHistory(
+                valid_suggestions=available_actions
+            ),
+            # Give them a list of autocomplete actions based on the valid actions.
+            completer=WordCompleter(available_actions),
+            # Pop up the completion list as they type.
+            complete_while_typing=True,
+        )
+        action = action.strip()
+        logging.debug(f"User Input: {action}")
+        if action == "q":
+            logging.debug("User quit the merge tool. Leaving merge files as they are.")
+            sys.exit(1)
+        # Dispatch based on action
+        # TODO: When should these objects be initialized?
+        # TODO: How should we configure these actions?
+        # TODO: Move to a verb object compositional approach?
+        # TODO: Move to async for actions?
+        merged_parameter = available_actions[action]()(
+            param_name,
+            current_param,
+            other_param,
+            ancestor_param,
+            current,
+            other,
+            ancestor,
+            # TODO: Update API so these don't need to be in-place updates?
+            partial_current,
+            partial_other,
+            partial_ancestor,
+            # The path to where the model actually lives.
+            args.path,
+        )
+        # Some of the actions result in deleting a parameter (it has a value of
+        # None) so if we see that, don't add this parameter name to the merged
+        # model.
+        if merged_parameter is None:
+            continue
+        merged_model[param_name] = merged_parameter
+
+    merged_model = metadata.Metadata(**merged_model).unflatten()
+    # Save merged_model to args.current %A
+    merged_model.write(args.current)
+    # Exit with 0 to signal the merge was good.
+    return 0
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    merge(args)

--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -147,7 +147,7 @@ def write_gitattributes(
     gitattributes_file.write("\n")
 
 
-def add_filter_theta_to_gitattributes(gitattributes: List[str], path: str) -> str:
+def add_theta_to_gitattributes(gitattributes: List[str], path: str) -> str:
     """Add a filter=theta that covers file_name.
 
     Parameters
@@ -174,11 +174,13 @@ def add_filter_theta_to_gitattributes(gitattributes: List[str], path: str) -> st
                 pattern_found = True
                 if not "filter=theta" in match.group("attributes"):
                     line = f"{line.rstrip()} filter=theta"
+                if not "merge=theta" in match.group("attributes"):
+                    line = f"{line.rstrip()} merge=theta"
         new_gitattributes.append(line)
     # If we don't find a matching pattern, add a new line that covers just this
     # specific file.
     if not pattern_found:
-        new_gitattributes.append(f"{path} filter=theta")
+        new_gitattributes.append(f"{path} filter=theta merge=theta")
     return new_gitattributes
 
 

--- a/git_theta/merges/__init__.py
+++ b/git_theta/merges/__init__.py
@@ -1,0 +1,9 @@
+"""Plugins for Model Merging.
+
+Note:
+  In order to dynamically create the menu of possible actions that describe what
+  each plug-in does, the plugins get imported at the start of the merge tool.
+  Therefore, plug-ins must not have slow side-effects that happen at import-time.
+"""
+
+from git_theta.merges.base import Merge, all_merge_handlers

--- a/git_theta/merges/average.py
+++ b/git_theta/merges/average.py
@@ -1,0 +1,213 @@
+"""Merge parameters by averaging them."""
+
+from typing import Dict, Any, Sequence
+import numpy as np
+from git_theta import metadata
+from git_theta.merges import Merge
+from git_theta.utils import DiffState, TEXT_STYLE
+from git_theta.types import ParamName
+from git_theta import updates
+from git_theta import params
+from git_theta import async_utils
+from git_theta import git_utils
+
+
+PartialModel = Dict[ParamName, Any]
+Parameter = Any
+
+
+# TODO: Add configurable interpolation parameters.
+# TODO: Control this class explosion, Average Merge can have it's own menu?
+# TODO: Move from a set of Inactive States to Active States?
+class Average(Merge):
+    DESCRIPTION = f"Average {TEXT_STYLE.format_who('our')} change and {TEXT_STYLE.format_who('their')} change together."
+    NAME = "average-ours-theirs"
+    SHORT_CUT = "avg-ab"
+    INACTIVE_STATES = frozenset(
+        {
+            # Averaging with the original parameter doesn't make sense?
+            DiffState.CHANGED_A,
+            DiffState.CHANGED_B,
+            # Averaging with only one added parameter doesn't make sense.
+            DiffState.ADDED_A,
+            DiffState.ADDED_B,
+            # Averaging with a deleted parameter doesn't make sense
+            DiffState.DELETED_A,
+            DiffState.DELETED_B,
+            DiffState.DELETED_BOTH,
+        }
+    )
+
+    def average(self, *params: Sequence[Parameter]) -> Parameter:
+        # Will convert to [#params, *param.shape] so sum over the leading dim.
+        return np.sum(params, axis=0) / len(params)
+
+    def read_parameter(
+        self, param: metadata.ParamMetadata, param_name: ParamName, path: str
+    ) -> Parameter:
+        update_handler = updates.get_update_handler(param.theta_metadata.update_type)(
+            params.get_update_serializer()
+        )
+        return async_utils.run(
+            update_handler.apply(param, param_name, git_utils.get_git_repo(), path)
+        )
+
+    def write_merged(self, averaged: Parameter, param_name: ParamName):
+        tensor_metadata = metadata.TensorMetadata.from_tensor(averaged)
+        update_handler = updates.get_update_handler("dense")(
+            params.get_update_serializer()
+        )
+        theta_metadata = metadata.ThetaMetadata("dense", None)
+        # Dense only needs these two...
+        lfs_metadata = async_utils.run(update_handler.write(averaged, param_name))
+        return metadata.ParamMetadata(
+            lfs_metadata=lfs_metadata,
+            tensor_metadata=tensor_metadata,
+            theta_metadata=theta_metadata,
+        )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        metadataA: metadata.Metadata,
+        metadataB: metadata.Metadata,
+        metadataO: metadata.Metadata,
+        modelA: PartialModel,
+        modelB: PartialModel,
+        modelO: PartialModel,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        # Load the current parameter
+        paramA = self.read_parameter(paramA, param_name, path)
+        # Load the other parameter
+        paramB = self.read_parameter(paramB, param_name, path)
+        result = self.average(paramA, paramB)
+        return self.write_merged(result, param_name)
+
+
+class AverageAll(Average):
+    DESCRIPTION = f"Average {TEXT_STYLE.format_who('our')} change, {TEXT_STYLE.format_who('their')} change, and the {TEXT_STYLE.format_who('original')} parameter together."
+    NAME = "average-all"
+    SHORT_CUT = "avg-all"
+    INACTIVE_STATES = frozenset(
+        {
+            # Need values for all 3 parameters.
+            DiffState.CHANGED_A,
+            DiffState.CHANGED_B,
+            # Averaging with only one added parameter doesn't make sense.
+            DiffState.ADDED_A,
+            DiffState.ADDED_B,
+            # Averaging with a deleted parameter doesn't make sense
+            DiffState.DELETED_A,
+            DiffState.DELETED_B,
+            DiffState.DELETED_BOTH,
+        }
+    )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        metadataA: metadata.Metadata,
+        metadataB: metadata.Metadata,
+        metadataO: metadata.Metadata,
+        modelA: PartialModel,
+        modelB: PartialModel,
+        modelO: PartialModel,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        # Load the current parameter
+        paramA = self.read_parameter(paramA, param_name, path)
+        # Load the other parameter
+        paramB = self.read_parameter(paramB, param_name, path)
+        # Load the original parameter
+        paramO = self.read_parameter(paramO, param_name, path)
+        result = self.average(paramA, paramB, paramO)
+        return self.write_merged(result, param_name)
+
+
+class AverageOursOriginal(Average):
+    DESCRIPTION = f"Average {TEXT_STYLE.format_who('our')} change and the {TEXT_STYLE.format_who('original')} parameter together."
+    NAME = "average-ours-original"
+    SHORT_CUT = "avg-ao"
+    INACTIVE_STATES = frozenset(
+        {
+            # Need a change in A
+            DiffState.CHANGED_B,
+            # Can average when a parameter wasn't there
+            DiffState.ADDED_A,
+            DiffState.ADDED_B,
+            DiffState.ADDED_BOTH,
+            # Averaging with a deleted parameter doesn't make sense
+            DiffState.DELETED_A,
+            DiffState.DELETED_B,
+            DiffState.DELETED_BOTH,
+        }
+    )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        metadataA: metadata.Metadata,
+        metadataB: metadata.Metadata,
+        metadataO: metadata.Metadata,
+        modelA: PartialModel,
+        modelB: PartialModel,
+        modelO: PartialModel,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        # Load the current parameter
+        paramA = self.read_parameter(paramA, param_name, path)
+        # Load the original parameter
+        paramO = self.read_parameter(paramO, param_name, path)
+        result = self.average(paramA, paramO)
+        return self.write_merged(result, param_name)
+
+
+class AverageTheirsOriginal(Average):
+    DESCRIPTION = f"Average {TEXT_STYLE.format_who('their')} change and the {TEXT_STYLE.format_who('original')} parameter together."
+    NAME = "average-theirs-original"
+    SHORT_CUT = "avg-to"
+    INACTIVE_STATES = frozenset(
+        {
+            # Need a change in B
+            DiffState.CHANGED_A,
+            # Can't average when a parameter wasn't there
+            DiffState.ADDED_A,
+            DiffState.ADDED_B,
+            DiffState.ADDED_BOTH,
+            # Averaging with a deleted parameter doesn't make sense
+            DiffState.DELETED_A,
+            DiffState.DELETED_B,
+            DiffState.DELETED_BOTH,
+        }
+    )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        metadataA: metadata.Metadata,
+        metadataB: metadata.Metadata,
+        metadataO: metadata.Metadata,
+        modelA: PartialModel,
+        modelB: PartialModel,
+        modelO: PartialModel,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        # Load the other parameter
+        paramB = self.read_parameter(paramB, param_name, path)
+        # Load the original parameter
+        paramO = self.read_parameter(paramO, param_name, path)
+        result = self.average(paramB, paramO)
+        return self.write_merged(result, param_name)

--- a/git_theta/merges/base.py
+++ b/git_theta/merges/base.py
@@ -1,0 +1,97 @@
+"""Plugins for Model Merging.
+
+Note:
+  In order to dynamically create the menu of possible actions that describe what
+  each plug-in does, the plugins get imported at the start of the merge tool.
+  Therefore, plug-ins must not have slow side-effects that happen at import-time.
+"""
+
+
+from abc import ABCMeta, abstractmethod
+import logging
+import sys
+from typing import FrozenSet, Dict, Tuple, Any
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+from git_theta import metadata
+from git_theta import utils
+
+
+ParamName = Tuple[str, ...]
+Parameter = Any
+PartialModel = Dict[ParamName, Parameter]
+
+
+class PrintableABCMeta(ABCMeta):
+    """Add custom `str` to /classes/, not objects."""
+
+    def __str__(cls):
+        return f"{cls.NAME}: {cls.DESCRIPTION}"
+
+
+class Merge(metaclass=PrintableABCMeta):
+    """A Plug-in that handles parameter merging.
+
+    Note:
+      Informational string about the plugin can contain `prompt_toolkit`
+      supported HTML markup for styling and coloring text.
+    """
+
+    DESCRIPTION: str = "Description of Merge Action, shown in menu."
+    NAME: str = "Unique name of the merge, to look up the plugin with."
+    SHORT_CUT: str = "A Request keyboard shortcut to use during merging."
+    # States where this action will not appear in the menu.
+    INACTIVE_STATES: FrozenSet[utils.DiffState] = frozenset()
+
+    def __call__(self, param_name, *args, **kwargs):
+        logging.info(f"Running {self.NAME} merge on parameter {'/'.join(param_name,)}")
+        return self.merge(param_name, *args, **kwargs)
+
+    @abstractmethod
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        metadataA: metadata.Metadata,
+        metadataB: metadata.Metadata,
+        metadataO: metadata.Metadata,
+        modelA: PartialModel,
+        modelB: PartialModel,
+        modelO: PartialModel,
+        path: str,
+    ) -> metadata.ParamMetadata:
+        """Merge parameters parameters.
+
+        Arguments
+        ---------
+            param_name: The name of the parameter we are looking at.
+            paramA: The parameter metadata from branch A (current).
+            paramB: The parameter metadata from branch B (other).
+            paramO: The parameter metadata from the ancestor.
+            metadataA: The full model metadata from branch A (current).
+            metadataB: The full model metadata from branch B (other).
+            metadataO: The full model metadata from the ancestor.
+            modelA: A partially filled in model of real parameter values from
+                branch A (current). Allows caching and reuse for any sort of
+                "full model" merging method.
+            modelB: A partially filled in model of real parameter values from
+                branch B (other). Allows caching and reuse for any sort of
+                "full model" merging method.
+            modelO: A partially filled in model of real parameter values from
+                the ancestor. Allows caching and reuse for any sort of
+                "full model" merging method.
+            path: The path to where the model actually lives.
+        """
+
+
+def all_merge_handlers() -> Dict[str, Merge]:
+    """Enumerate and Load (import) all merge plugins."""
+    discovered_plugins = entry_points(group="git_theta.plugins.merges")
+    loaded_plugins = {ep.name: ep.load() for ep in discovered_plugins}
+    return loaded_plugins

--- a/git_theta/merges/take.py
+++ b/git_theta/merges/take.py
@@ -1,0 +1,73 @@
+"""Merge operations that select one version or another."""
+
+from git_theta import metadata
+from git_theta.merges import Merge
+from git_theta.utils import DiffState, TEXT_STYLE
+from git_theta.types import ParamName
+
+
+class TakeUs(Merge):
+    DESCRIPTION = f"Use {TEXT_STYLE.format_who('our')} change to the parameter."
+    NAME = "take_us"
+    SHORT_CUT = "tu"
+    # If only they made a change take "us" doesn't make sense.
+    INACTIVE_STATES = frozenset(
+        {DiffState.CHANGED_B, DiffState.ADDED_B, DiffState.DELETED_B}
+    )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        *args,
+        **kwargs,
+    ) -> metadata.ParamMetadata:
+        """Grab the changes from branch A (current)."""
+        return paramA
+
+
+class TakeThem(Merge):
+    DESCRIPTION = f"Use {TEXT_STYLE.format_who('their')} change to the parameter."
+    NAME = "take_them"
+    SHORT_CUT = "tt"
+    # If only we made a change take "them" doesn't make sense.
+    INACTIVE_STATES = frozenset(
+        {
+            DiffState.CHANGED_A,
+            DiffState.ADDED_A,
+            DiffState.DELETED_A,
+        }
+    )
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        *args,
+        **kwargs,
+    ) -> metadata.ParamMetadata:
+        """Grab the changes from branch B (other)."""
+        return paramB
+
+
+class TakeOriginal(Merge):
+    DESCRIPTION = f"Use the {TEXT_STYLE.format_who('original')} parameter."
+    NAME = "take_original"
+    SHORT_CUT = "to"
+    INACTIVE_STATES = frozenset({})
+
+    def merge(
+        self,
+        param_name: ParamName,
+        paramA: metadata.ParamMetadata,
+        paramB: metadata.ParamMetadata,
+        paramO: metadata.ParamMetadata,
+        *args,
+        **kwargs,
+    ) -> metadata.ParamMetadata:
+        """Grab the changes from the ancestor."""
+        return paramO

--- a/git_theta/types.py
+++ b/git_theta/types.py
@@ -1,0 +1,6 @@
+"""Common types used in git-theta."""
+
+
+from typing import Tuple
+
+ParamName = Tuple[str, ...]

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -1,9 +1,54 @@
-"""Utilities for git theta"""
+"""Utilities for git theta."""
 
-import os
-from typing import Dict, Any, Tuple, Union, Callable
+import dataclasses
+from enum import Enum
+import functools
 import re
 import subprocess
+from types import MethodType
+from typing import Dict, Any, Tuple, Union, Callable, Iterable, Optional
+
+
+def _format(self, value, tag):
+    """Wrap `value` in HTML like <tag>s."""
+    return f"<{getattr(self, tag)}>{value}</{getattr(self, tag)}>"
+
+
+# TODO: Make configurable
+@dataclasses.dataclass
+class TextStyle:
+    param: str = "purple"
+    model: str = "cyan"
+    who: str = "u"
+    changed: str = "yellow"
+    added: str = "green"
+    deleted: str = "red"
+
+    # TODO: Move this to classlevel code gen?
+    def __post_init__(self):
+        # Add format_field() methods to the object for each field.
+        for field in dataclasses.fields(self):
+            field = field.name
+            method = MethodType(functools.partial(_format, tag=field), self)
+            setattr(self, f"format_{field}", method)
+
+
+TEXT_STYLE = TextStyle()
+
+
+# TODO: Defer the creation of enum text so we don't need an instantiated
+# TextStyle at import time.
+class DiffState(Enum):
+    EQUAL = "All parameter values are equal."
+    CHANGED_A = f"{TEXT_STYLE.format_who('We')} <b>{TEXT_STYLE.format_changed('changed')}</b> this parameter."
+    CHANGED_B = f"{TEXT_STYLE.format_who('They')} <b>{TEXT_STYLE.format_changed('changed')}</b> this parameter."
+    CHANGED_BOTH = f"{TEXT_STYLE.format_who('Both')} them and us <b>{TEXT_STYLE.format_changed('changed')}</b> this parameter."
+    DELETED_A = f"{TEXT_STYLE.format_who('We')} <b>{TEXT_STYLE.format_deleted('deleted')}</b> this parameter."
+    DELETED_B = f"{TEXT_STYLE.format_who('They')} <b>{TEXT_STYLE.format_deleted('deleted')}</b> this parameter."
+    DELETED_BOTH = f"{TEXT_STYLE.format_who('Both')} them and us <b>{TEXT_STYLE.format_deleted('deleted')}</b> this parameter."
+    ADDED_A = f"{TEXT_STYLE.format_who('We')} <b>{TEXT_STYLE.format_added('added')}</b> this parameter."
+    ADDED_B = f"{TEXT_STYLE.format_who('They')} <b>{TEXT_STYLE.format_added('added')}</b> this parameter."
+    ADDED_BOTH = f"{TEXT_STYLE.format_who('Both')} them and us <b>{TEXT_STYLE.format_added('added')}</b> this parameter."
 
 
 class EnvVarConstants:
@@ -99,3 +144,73 @@ def remove_suffix(s: str, suffix: str) -> str:
     if suffix and s.endswith(suffix):
         return s[: -len(suffix)]
     return s[:]
+
+
+class Trie:
+    """Data structure for O(n) prefix existence checking."""
+
+    def __init__(self, char: Optional[str] = None):
+        self.char = char  # Really only for debugging.
+        self.next: Dict[str, Trie] = {}
+        self.is_word = False
+
+    def insert(self, word: str):
+        # If there are no more letters to add we must be a full word.
+        if not word:
+            self.is_word = True
+            return
+        # Get the node for the next character.
+        first_char = word[0]
+        # Explicit checks over something like ".get" to ensure we only make a
+        # node if we have too. Also avoid defaultdict so we don't accidentally
+        # create a node during search.
+        if first_char not in self.next:
+            node = self.__class__(first_char)
+            self.next[first_char] = node
+        else:
+            node = self.next[first_char]
+        suffix = word[1:]
+        # Recurse
+        node.insert(suffix)
+
+    def _query(self, word: str) -> "Trie":
+        """Find the Node associated with `word`."""
+        # If there are no more characters we are the end of the line.
+        if not word:
+            return self
+        # Get the next node, raise key error if prefix + char is not one we have
+        # seen before.
+        return self.next[word[0]]._query(word[1:])
+
+    def prefix(self, word: str) -> bool:
+        # Note, a full word needs to be part of a longer word to be a prefix.
+        # i.e. It has characters that come after it.
+        try:
+            node = self._query(word)
+            # Does the node have continuations?
+            return bool(node.next)
+        # We didn't make it until the end of the word.
+        except KeyError:
+            return False
+
+    def __contains__(self, word: str) -> bool:
+        # Note, this is O(n) so if there is a set of words it would be faster to
+        # check that.
+        try:
+            node = self._query(word)
+            # Does the node represent a word?
+            return node.is_word
+        # We didn't make it until the end of the word.
+        except KeyError:
+            return False
+
+    @classmethod
+    def from_iterable(cls, words: Iterable[str]) -> "Trie":
+        """Build a trie for some collection of words."""
+        root = cls()
+        for word in words:
+            root.insert(word)
+        return root
+
+    def __str__(self):
+        return f"{self.__class__.__name__}(char={self.char}, is_word={self.is_word}, next={self.next.keys()})"

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     url="https://github.com/r-three/checkpoint-vcs",
     packages=find_packages(),
     package_data={"git_theta": ["hooks/post-commit", "hooks/pre-push"]},
-    scripts=["bin/git-theta", "bin/git-theta-filter"],
+    scripts=["bin/git-theta", "bin/git-theta-filter", "bin/git-theta-merge"],
     long_description="Version control system for model checkpoints.",
     python_requires=">=3.7",
     classifiers=[
@@ -92,6 +92,15 @@ setup(
             "dense = git_theta.updates.dense:DenseUpdate",
             "sparse = git_theta.updates.sparse:SparseUpdate",
             "low-rank = git_theta.updates.low_rank:LowRankUpdate",
+        ],
+        "git_theta.plugins.merges": [
+            "take_us = git_theta.merges.take:TakeUs",
+            "take_them = git_theta.merges.take:TakeThem",
+            "take_original = git_theta.merges.take:TakeOriginal",
+            "average-ours-theirs = git_theta.merges.average:Average",
+            "average-all = git_theta.merges.average:AverageAll",
+            "average-ours-original = git_theta.merges.average:AverageOursOriginal",
+            "average-theirs-original = git_theta.merges.average:AverageTheirsOriginal",
         ],
     },
 )

--- a/tests/git_utils_test.py
+++ b/tests/git_utils_test.py
@@ -6,65 +6,65 @@ import pytest
 from git_theta import git_utils
 
 
-def test_add_filter_gitattributes_empty_file():
-    assert git_utils.add_filter_theta_to_gitattributes([], "example") == [
-        "example filter=theta"
+def test_add_theta_gitattributes_empty_file():
+    assert git_utils.add_theta_to_gitattributes([], "example") == [
+        "example filter=theta merge=theta"
     ]
 
 
-def test_add_filter_gitattributes_no_match():
+def test_add_theta_gitattributes_no_match():
     atts = [
         "Some-other-path filter=lfs",
-        "*-cool-models.pt filter=theta",
+        "*-cool-models.pt filter=theta merge=theta",
     ]
     model_path = "path/to/my/model.pt"
     assert (
-        git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"{model_path} filter=theta"
+        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+        == f"{model_path} filter=theta merge=theta"
     )
 
 
-def test_add_filter_gitattributes_exact_match():
+def test_add_theta_gitattributes_exact_match():
     model_path = "really/cool/model/yall.ckpt"
     atts = [f"{model_path} filter=lfs"]
     assert (
-        git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"{model_path} filter=lfs filter=theta"
+        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+        == f"{model_path} filter=lfs filter=theta merge=theta"
     )
 
 
-def test_add_filter_gitattributes_pattern_match():
+def test_add_theta_gitattributes_pattern_match():
     model_path = "literal-the-best-checkpoint.pt"
     atts = ["*.pt thing"]
     assert (
-        git_utils.add_filter_theta_to_gitattributes(atts, model_path)[-1]
-        == f"*.pt thing filter=theta"
+        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+        == f"*.pt thing filter=theta merge=theta"
     )
 
 
-def test_add_filter_gitattributes_multiple_matches():
+def test_add_theta_gitattributes_multiple_matches():
     model_path = "100-on-mnist.npy"
     atts = ["*.npy other-filter", f"{model_path} other-filter"]
-    assert git_utils.add_filter_theta_to_gitattributes(atts, model_path) == [
-        f"{attr} filter=theta" for attr in atts
+    assert git_utils.add_theta_to_gitattributes(atts, model_path) == [
+        f"{attr} filter=theta merge=theta" for attr in atts
     ]
 
 
-def test_add_filter_gitattributes_match_with_theta_already():
+def test_add_theta_gitattributes_match_with_theta_already():
     model_path = "my-bad-model.chkp"
-    atts = ["my-*-model.chkp filter=theta"]
-    assert git_utils.add_filter_theta_to_gitattributes(atts, model_path) == atts
+    atts = ["my-*-model.chkp filter=theta merge=theta"]
+    assert git_utils.add_theta_to_gitattributes(atts, model_path) == atts
 
 
-def test_add_filter_gitattributes_rest_unchanged():
+def test_add_theta_gitattributes_rest_unchanged():
     model_path = "model-v3.pt"
     atts = [
-        "some-other-path filter=theta",
+        "some-other-path filter=theta merge=theta",
         "really-reaaaally-big-files filter=lfs",
         r"model-v\d.pt filter",
-        "another filter=theta",
+        "another filter=theta merge=theta",
     ]
-    results = git_utils.add_filter_theta_to_gitattributes(atts, model_path)
+    results = git_utils.add_theta_to_gitattributes(atts, model_path)
     for i, (a, r) in enumerate(zip(atts, results)):
         if i == 2:
             continue
@@ -74,7 +74,7 @@ def test_add_filter_gitattributes_rest_unchanged():
 @pytest.fixture
 def gitattributes():
     return [
-        "*.pt filter=theta",
+        "*.pt filter=theta merge=theta",
         "*.png filter=lfs",
         "really-big-file filter=lfs",
         "something else, who knows how cool it could be",


### PR DESCRIPTION
This PR adds a custom git-theta aware merge driver.

The driver loads all three versions of the (cleaned) checkpoint, branch A, branch B, and the merge-base (the ancestor commit for both). It then iterates through each parameter checking if it has changed.

When it finds a change it creates a prompt and collects user actions on what to do next. These actions are defined via a new plugin type. Additionaly these plugins register what strings they want to use as activation commands and what kind of merge situations they are valid for.

The prompt includes several qol things like type-ahead autocomplete, autosuggest, and input validation meaning that one cannot enter invalid commands.

closes https://github.com/r-three/git-theta/issues/24