### PR TITLE
Add `GIT_THETA_MAX_CONCURRENCY` that can limit the number of async functions running at one time.

### DIFF
--- a/bin/git-theta-filter
+++ b/bin/git-theta-filter
@@ -130,7 +130,13 @@ def clean(args):
     # Sort the keys so we don't get changing diffs based on serialization order.
     sorted_checkpoint = dict(sorted(model_checkpoint.flatten().items()))
     new_metadata = metadata.Metadata(
-        **async_utils.run(async_utils.run_map(sorted_checkpoint, _clean))
+        **async_utils.run(
+            async_utils.run_map(
+                sorted_checkpoint,
+                _clean,
+                max_concurrency=EnvVarConstants.MAX_CONCURRENCY,
+            )
+        )
     )
 
     new_metadata.unflatten().write(sys.stdout)
@@ -155,7 +161,11 @@ def smudge(args):
         )
         return param_keys, param_value
 
-    model_dict = async_utils.run(async_utils.run_map(curr_metadata, _smudge))
+    model_dict = async_utils.run(
+        async_utils.run_map(
+            curr_metadata, _smudge, max_concurrency=EnvVarConstants.MAX_CONCURRENCY
+        )
+    )
 
     checkpoint_handler = checkpoints.get_checkpoint_handler()
     model_checkpoint = checkpoint_handler(model_dict).unflatten()

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -71,6 +71,7 @@ class EnvVarConstants:
     LSH_SIGNATURE_SIZE = EnvVar(name="GIT_THETA_LSH_SIGNATURE_SIZE", default=16)
     LSH_THRESHOLD = EnvVar(name="GIT_THETA_LSH_THRESHOLD", default=1e-6)
     LSH_POOL_SIZE = EnvVar(name="GIT_THETA_LSH_POOL_SIZE", default=10_000)
+    MAX_CONCURRENCY = EnvVar(name="GIT_THETA_MAX_CONCURRENCY", default=-1)
 
 
 def flatten(


### PR DESCRIPTION
When working with larger models (T0 3B, etc.) one can occasionally hit a "Too many open files" error as async calls to git-lfs, tensorstore and the like grab file descriptors.

One way to fix this is to change the limit on the number of open files a process can have (`ulimit -n \d+` on linux) but it might be different on different systems.

This offers a solution that might be easier for users and would allow us to ship with a sensible default so users don't install and get hit with a weird error on the first model they try to checkpoint.

But for now the default is full concurrency.