### PR TITLE
Add abstract Class Attributes

### DIFF
--- a/git_theta/checkpoints/base.py
+++ b/git_theta/checkpoints/base.py
@@ -14,13 +14,11 @@ else:
 from git_theta import utils
 
 
+@utils.abstract_classattributes("name")
 class Checkpoint(dict, metaclass=ABCMeta):
     """Abstract base class for wrapping checkpoint formats."""
 
-    @property
-    @abstractmethod
-    def name(self):
-        """The name of this checkpoint handler, can be used to lookup the plugin."""
+    name: str = NotImplemented  # The name of this checkpoint handler, can be used to lookup the plugin.
 
     @classmethod
     def from_file(cls, checkpoint_path):

--- a/git_theta/checkpoints/flax_checkpoint.py
+++ b/git_theta/checkpoints/flax_checkpoint.py
@@ -6,6 +6,9 @@ from file_or_name import file_or_name
 
 
 class FlaxCheckpoint(Checkpoint):
+
+    name: str = "flax"
+
     @classmethod
     @file_or_name(checkpoint_path="rb")
     def load(cls, checkpoint_path, **kwargs):

--- a/git_theta/checkpoints/pickled_dict_checkpoint.py
+++ b/git_theta/checkpoints/pickled_dict_checkpoint.py
@@ -9,6 +9,8 @@ from git_theta.checkpoints import Checkpoint
 class PickledDictCheckpoint(Checkpoint):
     """Class for wrapping picked dict checkpoints, commonly used with PyTorch."""
 
+    name: str = "pickled_dict"
+
     @classmethod
     def load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.

--- a/git_theta/checkpoints/tensorflow_checkpoint.py
+++ b/git_theta/checkpoints/tensorflow_checkpoint.py
@@ -26,11 +26,8 @@ class DynamicNetwork(tf.keras.Model):
 class TensorFlowCheckpoint(Checkpoint):
     """Process a TensorFlow checkpoint via `tf.keras.Model.save_weights`. (no computation graph included)."""
 
+    name: str = "tensorflow-checkpoint"
     VALUE_STRING = ".ATTRIBUTES/VARIABLE_VALUE"
-
-    @property
-    def name(self):
-        return "tensorflow-checkpoint"
 
     @staticmethod
     def is_parameter(param_name: str) -> bool:
@@ -62,9 +59,7 @@ class TensorFlowCheckpoint(Checkpoint):
 class TensorFlowSavedModel(Checkpoint):
     """Process a TensorFlow SavedModel (computation graph included)."""
 
-    @property
-    def name(self):
-        return "tensorflow-savedmodel"
+    name: str = "tensorflow-savedmodel"
 
     @classmethod
     def load(cls, checkpoint_path: str):

--- a/git_theta/merges/base.py
+++ b/git_theta/merges/base.py
@@ -33,6 +33,7 @@ class PrintableABCMeta(ABCMeta):
         return f"{cls.NAME}: {cls.DESCRIPTION}"
 
 
+@utils.abstract_classattributes("DESCRIPTION", "NAME", "SHORT_CUT", "INACTIVE_STATES")
 class Merge(metaclass=PrintableABCMeta):
     """A Plug-in that handles parameter merging.
 
@@ -41,11 +42,14 @@ class Merge(metaclass=PrintableABCMeta):
       supported HTML markup for styling and coloring text.
     """
 
-    DESCRIPTION: str = "Description of Merge Action, shown in menu."
-    NAME: str = "Unique name of the merge, to look up the plugin with."
-    SHORT_CUT: str = "A Request keyboard shortcut to use during merging."
-    # States where this action will not appear in the menu.
-    INACTIVE_STATES: FrozenSet[utils.DiffState] = frozenset()
+    DESCRIPTION: str = NotImplemented  # Description of Merge Action, shown in menu.
+    NAME: str = NotImplemented  # Unique name of the merge, to look up the plugin with.
+    SHORT_CUT: str = (
+        NotImplemented  # A Request keyboard shortcut to use during merging.
+    )
+    INACTIVE_STATES: FrozenSet[
+        utils.DiffState
+    ] = frozenset()  # States where this action will not appear in the menu.
 
     def __call__(self, param_name, *args, **kwargs):
         logging.info(f"Running {self.NAME} merge on parameter {'/'.join(param_name,)}")

--- a/git_theta/updates/base.py
+++ b/git_theta/updates/base.py
@@ -20,16 +20,14 @@ from git_theta import git_utils, utils, params, metadata
 Parameter = np.ndarray
 
 
+@utils.abstract_classattributes("name")
 class Update(metaclass=ABCMeta):
     """Base class for parameter update plugins."""
 
+    name: str = NotImplemented  # The name used to lookup the plug-in.
+
     def __init__(self, serializer: params.Serializer):
         self.serializer = serializer
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """The name used to lookup the plug-in."""
 
     async def read(self, param_metadata: metadata.ParamMetadata) -> Parameter:
         """Read in and deserialize a single parameter value based metadata."""

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -12,9 +12,7 @@ Parameter = Any
 class DenseUpdate(Update):
     """An update where all parameters are changed."""
 
-    @property
-    def name(self):
-        return "dense"
+    name: str = "dense"
 
     async def apply(self, param_metadata, param_keys, *args, **kwargs) -> Parameter:
         logging.debug(f"Reading Dense update for {'/'.join(param_keys)}")

--- a/git_theta/updates/low_rank.py
+++ b/git_theta/updates/low_rank.py
@@ -12,6 +12,8 @@ Parameter = Any
 class LowRankUpdate(IncrementalUpdate):
     """An update make for 2 low rank matrices."""
 
+    name: str = "low-rank"
+
     # TODO: Make these configuration options easy set.
     def __init__(
         self, *args, K: Optional[int] = None, threshold: float = 1e-11, **kwargs
@@ -19,10 +21,6 @@ class LowRankUpdate(IncrementalUpdate):
         super().__init__(*args, **kwargs)
         self.K = K
         self.threshold = threshold
-
-    @property
-    def name(self):
-        return "low-rank"
 
     async def calculate_update(
         self, parameter: Parameter, previous_parameter: Parameter

--- a/git_theta/updates/sparse.py
+++ b/git_theta/updates/sparse.py
@@ -13,14 +13,12 @@ Parameter = Any
 class SparseUpdate(IncrementalUpdate):
     """An update where only some parameters are touched."""
 
+    name: str = "sparse"
+
     def __init__(self, serializer: params.Serializer, threshold: float = 1e-12):
         # TODO: Make threshold configurable
         super().__init__(serializer)
         self.threshold = threshold
-
-    @property
-    def name(self):
-        return "sparse"
 
     async def calculate_update(
         self, parameter: Parameter, previous_parameter: Parameter

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -3,6 +3,7 @@
 import dataclasses
 from enum import Enum
 import functools
+import inspect
 import re
 import subprocess
 from types import MethodType
@@ -231,3 +232,58 @@ class Trie:
 
     def __str__(self):
         return f"{self.__class__.__name__}(char={self.char}, is_word={self.is_word}, next={self.next.keys()})"
+
+
+def abstract_classattributes(*attributes):
+    """Force subclasses to define some class attributes."""
+
+    # Note, we are modifying the class with the decorator, not wrapping it so we
+    # don't need @functools.wraps to maintain information about our class.
+    def inner(base_cls):
+        # First set all attributes (on the base class) to NotImplemented
+        # so the subclasses will inherit them and give us something to compare to.
+        for attribute in attributes:
+            setattr(base_cls, attribute, NotImplemented)
+
+        # Save the original verson of the init, this lets us exectue it to make
+        # sure we preserve any functionality defined by the base class.
+        og_init_subclass = base_cls.__init_subclass__
+
+        # A new version of __init_subclass__ that checks for our attributes.
+        # TODO: How does this change things like __doc__ and __name__?
+        def enforcing_init_subclass(cls, **kwargs):
+            # Call the original one, if they didn't override the implementation it
+            # doesn't take cls as an argument. Just try each version to see what works.
+            try:
+                og_init_subclass(cls, **kwargs)
+            except TypeError:
+                og_init_subclass(**kwargs)
+
+            # Collect all attributes on the subclass now, that still have their
+            # default (inherited) value.
+            missing_attributes = []
+            for attribute in attributes:
+                if getattr(cls, attribute, NotImplemented) is NotImplemented:
+                    missing_attributes.append(attribute)
+
+            # Error out if they are a concrete class and missing things.
+            if missing_attributes and not inspect.isabstract(cls):
+                missing = [f'"{attr}"' for attr in missing_attributes]
+                plural = ""
+                # Make it look pretty and handle pluralization.
+                if len(missing) > 1:
+                    missing[-1] = f"and {missing[-1]}"
+                    plural = "s"
+                missing = ", ".join(missing)
+                raise NotImplementedError(
+                    f"Abstract Attribute{plural} {missing} missing "
+                    "on class {cls.__name__}"
+                )
+
+            return cls
+
+        # Set this as the new __init_subclass__ and make sure it is a class method.
+        base_cls.__init_subclass__ = classmethod(enforcing_init_subclass)
+        return base_cls
+
+    return inner


### PR DESCRIPTION
The PR changes the `name` attribute on plug-ins from being properties to being class attributes. This makes it possible to access information about the plug-in (name etc) without having to instantiate it.

It also adds a new class decorator that allows us to enforce the defining of an attribute in subclasses (i.e. user plugins), similar to the way we can for object-level properties.