### PR TITLE
Move scripts to entry points.

### DIFF
--- a/git_theta/scripts/git_theta.py
+++ b/git_theta/scripts/git_theta.py
@@ -158,7 +158,7 @@ def add(args, unparsed_args):
         repo.git.add(*unparsed_args)
 
 
-if __name__ == "__main__":
+def main():
     args, unparsed_args = parse_args()
     if not args.func == install:
         git_utils.set_hooks()
@@ -166,3 +166,7 @@ if __name__ == "__main__":
         args.func(args, unparsed_args)
     else:
         args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/git_theta/scripts/git_theta.py
+++ b/git_theta/scripts/git_theta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+"""Installation and .git manipulation scripts."""
 
 import argparse
 import sys

--- a/git_theta/scripts/git_theta_filter.py
+++ b/git_theta/scripts/git_theta_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+"""Clean and Smudge filters for version controlling machine learning models."""
 
 import argparse
 import sys

--- a/git_theta/scripts/git_theta_filter.py
+++ b/git_theta/scripts/git_theta_filter.py
@@ -172,7 +172,11 @@ def smudge(args):
     model_checkpoint.save(sys.stdout.buffer)
 
 
-if __name__ == "__main__":
+def main():
     args = parse_args()
     git_utils.set_hooks()
     args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/git_theta/scripts/git_theta_merge.py
+++ b/git_theta/scripts/git_theta_merge.py
@@ -380,9 +380,13 @@ def merge(args):
     return 0
 
 
-if __name__ == "__main__":
+def main():
     args = parse_args()
     if EnvVarConstants.MANUAL_MERGE:
         manual_merge(args)
     else:
         merge(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/git_theta/scripts/git_theta_merge.py
+++ b/git_theta/scripts/git_theta_merge.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+"""Custom git-theta merge tool."""
 
 import asyncio
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     url="https://github.com/r-three/checkpoint-vcs",
     packages=find_packages(),
     package_data={"git_theta": ["hooks/post-commit", "hooks/pre-push"]},
-    scripts=["bin/git-theta", "bin/git-theta-filter", "bin/git-theta-merge"],
     long_description="Version control system for model checkpoints.",
     python_requires=">=3.7",
     classifiers=[
@@ -87,6 +86,11 @@ setup(
     },
     # TODO: Can we auto register these?
     entry_points={
+        "console_scripts": [
+            "git-theta = git_theta.scripts.git_theta:main",
+            "git-theta-filter = git_theta.scripts.git_theta_filter:main",
+            "git-theta-merge = git_theta.scripts.git_theta_merge:main",
+        ],
         "git_theta.plugins.checkpoints": [
             "pytorch = git_theta.checkpoints.pickled_dict_checkpoint:PickledDictCheckpoint",
             "pickled-dict = git_theta.checkpoints.pickled_dict_checkpoint:PickledDictCheckpoint",


### PR DESCRIPTION
This PR updates the binaries from git-theta to live in `git_theta/scripts/...` instead of `bin/...` and uses the `console_scripts` entrypoint instead of the `scripts` argument.

The former is the recommended method and is supposed to smooth over some possible windows issues. Additionally this makes it easier to make changes to the runnable files in an editable install (you no longer need to re-run pip install after a change).

There is no user-facing change as the commands `git-theta`, `git-theta-filter`, etc. still work (they are the entry point names).

closes https://github.com/r-three/git-theta/issues/138