### PR TITLE
Include some commit information in the merge ui

### DIFF
--- a/bin/git-theta-merge
+++ b/bin/git-theta-merge
@@ -14,7 +14,7 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import WordCompleter
 from git_theta import metadata
 from git_theta import merges
-from git_theta.utils import DiffState, Trie, TEXT_STYLE
+from git_theta.utils import DiffState, Trie, TEXT_STYLE, NoResult
 
 
 logging.basicConfig(
@@ -195,6 +195,9 @@ def merge(args):
     handlers = merges.all_merge_handlers()
     short_cuts = make_short_cuts(handlers)
 
+    # Trigger the context merge for summary of branches.
+    handlers["context"]().merge()
+
     # A place to aggregate metadata for the merged model.
     merged_model = {}
     # A place to store loaded parameters to enable reuse/caching. Currently
@@ -258,50 +261,54 @@ def merge(args):
             f' in model <i><style bg="{TEXT_STYLE.model}">{args.path}</style></i>'
         )
 
-        # User action selection.
-        action = session.prompt(
-            # Show the menu
-            text,
-            # Show the merge context
-            bottom_toolbar=context,
-            # Validate that their input is either a valid action or is the
-            # prefix of a valid action. This lets us alert early if their input
-            # is not in the autocomplete menu.
-            validator=CommandValidator(available_actions, available_prefixes),
-            # Suggest completions they have used before, accept with ->
-            auto_suggest=FilteredAutoSuggestFromHistory(
-                valid_suggestions=available_actions
-            ),
-            # Give them a list of autocomplete actions based on the valid actions.
-            completer=WordCompleter(available_actions),
-            # Pop up the completion list as they type.
-            complete_while_typing=True,
-        )
-        action = action.strip()
-        logging.debug(f"User Input: {action}")
-        if action == "q":
-            logging.debug("User quit the merge tool. Leaving merge files as they are.")
-            sys.exit(1)
-        # Dispatch based on action
-        # TODO: When should these objects be initialized?
-        # TODO: How should we configure these actions?
-        # TODO: Move to a verb object compositional approach?
-        # TODO: Move to async for actions?
-        merged_parameter = available_actions[action]()(
-            param_name,
-            current_param,
-            other_param,
-            ancestor_param,
-            current,
-            other,
-            ancestor,
-            # TODO: Update API so these don't need to be in-place updates?
-            partial_current,
-            partial_other,
-            partial_ancestor,
-            # The path to where the model actually lives.
-            args.path,
-        )
+        merged_parameter = NoResult
+        while merged_parameter is NoResult:
+            # User action selection.
+            action = session.prompt(
+                # Show the menu
+                text,
+                # Show the merge context
+                bottom_toolbar=context,
+                # Validate that their input is either a valid action or is the
+                # prefix of a valid action. This lets us alert early if their input
+                # is not in the autocomplete menu.
+                validator=CommandValidator(available_actions, available_prefixes),
+                # Suggest completions they have used before, accept with ->
+                auto_suggest=FilteredAutoSuggestFromHistory(
+                    valid_suggestions=available_actions
+                ),
+                # Give them a list of autocomplete actions based on the valid actions.
+                completer=WordCompleter(available_actions),
+                # Pop up the completion list as they type.
+                complete_while_typing=True,
+            )
+            action = action.strip()
+            logging.debug(f"User Input: {action}")
+            if action == "q":
+                logging.debug(
+                    "User quit the merge tool. Leaving merge files as they are."
+                )
+                sys.exit(1)
+            # Dispatch based on action
+            # TODO: When should these objects be initialized?
+            # TODO: How should we configure these actions?
+            # TODO: Move to a verb object compositional approach?
+            # TODO: Move to async for actions?
+            merged_parameter = available_actions[action]()(
+                param_name,
+                current_param,
+                other_param,
+                ancestor_param,
+                current,
+                other,
+                ancestor,
+                # TODO: Update API so these don't need to be in-place updates?
+                partial_current,
+                partial_other,
+                partial_ancestor,
+                # The path to where the model actually lives.
+                args.path,
+            )
         # Some of the actions result in deleting a parameter (it has a value of
         # None) so if we see that, don't add this parameter name to the merged
         # model.

--- a/git_theta/merges/context.py
+++ b/git_theta/merges/context.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import os
+from prompt_toolkit import print_formatted_text
+from prompt_toolkit.formatted_text import HTML
+from git_theta.merges import Merge
+from git_theta.utils import DiffState, TEXT_STYLE, NoResult
+from git_theta.types import ParamName
+from git_theta import git_utils
+
+
+def get_other_commit_in_merge() -> str:
+    git_heads = [e for e in os.environ.keys() if e.startswith("GITHEAD_")]
+    if not git_heads:
+        return None
+    return git_heads[0].split("_", maxsplit=1)[-1]
+
+
+def trim_log(log: str, limit: int = 80) -> str:
+    if len(log) >= limit - 3:
+        return f"{log[:limit - 3]}..."
+    return f"{log}"
+
+
+class Context(Merge):
+    DESCRIPTION = f"Show extra information about what {TEXT_STYLE.format_who('us')} vs {TEXT_STYLE.format_who('them')} means."
+    NAME = "context"
+    SHORT_CUT = "c"
+    INACTIVE_STATES = frozenset()
+
+    def merge(self, *args, **kwargs):
+        repo = git_utils.get_git_repo()
+        other_hash = get_other_commit_in_merge()
+        other_commit = repo.commit(other_hash)
+        other_branch = repo.git.branch("--contains", other_hash).strip()
+        other_log = other_commit.summary
+
+        my_commit = repo.commit("HEAD")
+        my_hash = my_commit.hexsha
+        my_branch = repo.active_branch
+        my_log = my_commit.summary
+
+        print_formatted_text(
+            HTML(
+                "Merge Context:\n"
+                f"\t{TEXT_STYLE.format_who('us')},   {my_hash[:6]} ({my_branch}): {trim_log(my_log)}\n"
+                f"\t{TEXT_STYLE.format_who('them')}, {other_hash[:6]} ({other_branch}): {trim_log(other_log)}"
+            )
+        )
+
+        return NoResult

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -53,6 +53,10 @@ class DiffState(Enum):
     ADDED_BOTH = f"{TEXT_STYLE.format_who('Both')} them and us <b>{TEXT_STYLE.format_added('added')}</b> this parameter."
 
 
+class NoResult:
+    """A sentinel class used to mark no-action choices."""
+
+
 @dataclass
 class EnvVar:
     name: str

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
             "average-all = git_theta.merges.average:AverageAll",
             "average-ours-original = git_theta.merges.average:AverageOursOriginal",
             "average-theirs-original = git_theta.merges.average:AverageTheirsOriginal",
+            "context = git_theta.merges.context:Context",
         ],
     },
 )


### PR DESCRIPTION
This PR adds some information in the merge UI, it uses the `GITHEAD_${SHA}` env variable to tell what the other branch is and the git repo object for information about the current commit.

This summary is shown at the beginning of merging and can be shown again with the new "context" merge plugin.

This also adds the ability to have "no-op" merge plugins that do not advance the current parameter. Instead they do something like print the context and then re-display the menu of actions.

Below we can see the context menu shown at the start and as a result of the context plugin action
![image](https://user-images.githubusercontent.com/10950530/219750319-42f38f5d-9312-4d08-8414-792076cbd807.png)
(You can see a bit of another terminal on the lower left, so the weird extra letters won't actually show up. Sorry)

closes https://github.com/r-three/git-theta/issues/132