### PR TITLE
Manual Merge Escape Hatch

### DIFF
--- a/bin/git-theta-merge
+++ b/bin/git-theta-merge
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 
+import asyncio
 import argparse
 import itertools
 import logging
@@ -14,7 +15,8 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.completion import WordCompleter
 from git_theta import metadata
 from git_theta import merges
-from git_theta.utils import DiffState, Trie, TEXT_STYLE, NoResult
+from git_theta.utils import DiffState, Trie, TEXT_STYLE, NoResult, EnvVarConstants
+from git_theta import async_utils
 
 
 logging.basicConfig(
@@ -171,6 +173,39 @@ def build_menu(
     return menu
 
 
+def manual_merge(args):
+    logging.info(f"Writing model weights from {args.path} for manual merging.")
+
+    # TODO: Update smudge API to make it easier to call programatically.
+    async def load(name, path):
+        with open(path, "rb") as f:
+            raw_weights = (
+                await async_utils.subprocess_run(
+                    ["git-theta-filter", "smudge", args.path],
+                    f.read(),
+                    capture_output=True,
+                )
+            ).stdout
+        return name, raw_weights
+
+    checkpoints = {
+        "ours": args.current,
+        "theirs": args.other,
+        "ancestor": args.ancestor,
+    }
+
+    checkpoints = async_utils.run(async_utils.run_map(checkpoints, load))
+    for name, raw_weights in checkpoints.items():
+        with open(f"{name}.ckpt", "wb") as wf:
+            logging.info(f"Saving {name} model to {name}.ckpt")
+            wf.write(raw_weights)
+    logging.info(
+        "Manual Merging: Combine checkpoints as you wish, save the "
+        f"result to {args.path} and continue the merge."
+    )
+    sys.exit(1)
+
+
 def merge(args):
     """git-theta checkpoint aware merging."""
     print_formatted_text(
@@ -186,6 +221,7 @@ def merge(args):
     # Load the `cleaned` metadata file for commit on the other branch.
     other = metadata.Metadata.from_file(args.other)
     other = other.flatten()
+
     # Collect the list of all parameter names. NB: Names are collected from all
     # models as they may have been deleted/added on different branches.
     all_params = sorted(
@@ -325,4 +361,7 @@ def merge(args):
 
 if __name__ == "__main__":
     args = parse_args()
-    merge(args)
+    if EnvVarConstants.MANUAL_MERGE:
+        manual_merge(args)
+    else:
+        merge(args)

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -77,6 +77,7 @@ class EnvVarConstants:
     LSH_THRESHOLD = EnvVar(name="GIT_THETA_LSH_THRESHOLD", default=1e-6)
     LSH_POOL_SIZE = EnvVar(name="GIT_THETA_LSH_POOL_SIZE", default=10_000)
     MAX_CONCURRENCY = EnvVar(name="GIT_THETA_MAX_CONCURRENCY", default=-1)
+    MANUAL_MERGE = EnvVar(name="GIT_THETA_MANUAL_MERGE", default=False)
 
 
 def flatten(


### PR DESCRIPTION
This PR allows for a "manual" merge where the merge tools dumps three copies of the model to disk, the model as it lives on the current branch, the model as it is on the branch we are merging in, and the model as it was at the ancestor commit.

The 3 checkpoints can be manually combined, saved to the original path, and then commited to continue the merge.

This is currently triggered with the `GIT_THETA_MANUAL_MERGE=true` env variable.

closes https://github.com/r-three/git-theta/issues/164