### PR TITLE
try to cache actions

### DIFF
--- a/.github/workflows/end2endtest.yml
+++ b/.github/workflows/end2endtest.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"
+        cache-dependency-path: "setup.py"
     - name: Install Dependencies and Package
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+        cache: "pip"
+        cache-dependency-path: "setup.py"
     - name: Install Dependencies and Package
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Caching seems to be working.

See: https://github.com/r-three/git-theta/actions/runs/4633026393/jobs/8197788440 where deps take ~3mins and then https://github.com/r-three/git-theta/actions/runs/4633262776/jobs/8198283765 where deps take ~1min and it says the cache is restored.

The cache is based on a hash of `setup.py` so it should be pretty reusable

fixes https://github.com/r-three/git-theta/issues/199