### PR TITLE
Update sparse_update_test.py

### DIFF
--- a/tests/updates/sparse_update_test.py
+++ b/tests/updates/sparse_update_test.py
@@ -54,7 +54,7 @@ def test_known_sparsity(updater):
             sparse_updater.calculate_update(updated_parameter, parameter)
         )
         calc_sparsity = 1 - len(update_dict["data"]) / np.prod(parameter.shape)
-        np.testing.assert_allclose(calc_sparsity, 0.3, rtol=1e-6)
+        np.testing.assert_allclose(calc_sparsity, 0.3, rtol=1e-5)
 
 
 def test_monotonic_increasing_sparseness(updater):


### PR DESCRIPTION
Sometimes windows outputs 0.30001 instead of 0.30000 but it is def close enough for this test. Should fix that flakiness.