### PR TITLE
Updates logging to include Async Task Ids.

### DIFF
--- a/git_theta/metadata.py
+++ b/git_theta/metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import logging
 import re
 from collections import OrderedDict
 from typing import Any, ClassVar, Dict, TextIO, Tuple, Union
@@ -73,7 +74,9 @@ class TensorMetadata(MetadataField):
     def from_tensor(cls, tensor: np.ndarray) -> TensorMetadata:
         shape = str(tensor.shape)
         dtype = str(tensor.dtype)
+        logging.debug(f"Starting LSH Hash")
         hash = lsh.get_lsh().hash(tensor)
+        logging.debug(f"Finished LSH Hash")
         return cls(shape=shape, dtype=dtype, hash=hash)
 
 

--- a/git_theta/scripts/__init__.py
+++ b/git_theta/scripts/__init__.py
@@ -1,0 +1,28 @@
+"""Shared logging setup for scripts.
+
+This is not part of the main git_theta.__init__ as we don't want to configure
+logging if git_theta is being used as a library.
+"""
+
+import logging
+import os
+import tempfile
+
+import git_theta
+
+
+def configure_logging(exe_name: str):
+    format_str = f"{exe_name}: [%(asctime)s] [task %(task)s] [%(funcName)s] %(levelname)s - %(message)s"
+    logging.basicConfig(
+        level=getattr(
+            logging, git_theta.utils.EnvVarConstants.LOG_LEVEL.upper(), logging.DEBUG
+        ),
+        # Log to a file for clean/smudge as they don't appear on the console when called via git.
+        format=format_str,
+        handlers=[
+            git_theta.async_utils.AsyncTaskStreamHandler(),
+            git_theta.async_utils.AsyncTaskFileHandler(
+                filename=os.path.join(tempfile.gettempdir(), "git-theta.log")
+            ),
+        ],
+    )

--- a/git_theta/scripts/git_theta.py
+++ b/git_theta/scripts/git_theta.py
@@ -13,12 +13,10 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
+import git_theta
 from git_theta import async_utils, git_utils, metadata, theta, utils
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="git-theta: [%(asctime)s] [%(funcName)s] %(levelname)s - %(message)s",
-)
+git_theta.scripts.configure_logging("git-theta")
 
 
 def parse_args():

--- a/git_theta/scripts/git_theta_diff.py
+++ b/git_theta/scripts/git_theta_diff.py
@@ -5,7 +5,10 @@ import textwrap
 import numpy as np
 from colorama import Fore, Style
 
+import git_theta
 from git_theta import checkpoints, metadata
+
+git_theta.scripts.configure_logging("git-theta-diff")
 
 
 def parse_args():

--- a/git_theta/scripts/git_theta_merge.py
+++ b/git_theta/scripts/git_theta_merge.py
@@ -16,15 +16,11 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.validation import ValidationError, Validator
 
+import git_theta
 from git_theta import async_utils, merges, metadata
 from git_theta.utils import TEXT_STYLE, DiffState, EnvVarConstants, NoResult, Trie
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    # Log to a file for clean/smudge as they don't appear on the console when called via git.
-    filename=os.path.join(tempfile.gettempdir(), "git-theta.log"),
-    format="git-theta-merge: [%(asctime)s] %(levelname)s - %(message)s",
-)
+git_theta.scripts.configure_logging("git-theta-merge")
 
 
 def infer_state(

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -21,7 +21,7 @@ class DenseUpdate(Update):
         param_name = "/".join(param_keys)
         logging.debug(f"Reading Dense update for {param_name}")
         tensor = await self.read(param_metadata)
-        logging.debug(f"Read Dense update for {param_name}")
+        logging.debug(f"Finished Read Dense update for {param_name}")
         return tensor
 
     async def write(self, param, param_keys, *args, **kwargs) -> metadata.LfsMetadata:
@@ -29,7 +29,7 @@ class DenseUpdate(Update):
         logging.debug(f"Writing Dense update for {param_name}")
         logging.debug(f"Starting Serializing {param_name}")
         serialized = await self.serializer.serialize({"parameter": param})
-        logging.debug(f"Finsihed Serializing {param_name}")
+        logging.debug(f"Finished Serializing {param_name}")
         logging.debug(f"Starting git-lfs clean for {param_name}")
         lfs_pointer = await git_utils.git_lfs_clean(serialized)
         logging.debug(f"Finished git-lfs clean for {param_name}")

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -18,11 +18,19 @@ class DenseUpdate(Update):
         super().__init__(*args, **kwargs)
 
     async def apply(self, param_metadata, param_keys, *args, **kwargs) -> Parameter:
-        logging.debug(f"Reading Dense update for {'/'.join(param_keys)}")
-        return await self.read(param_metadata)
+        param_name = "/".join(param_keys)
+        logging.debug(f"Reading Dense update for {param_name}")
+        tensor = await self.read(param_metadata)
+        logging.debug(f"Read Dense update for {param_name}")
+        return tensor
 
     async def write(self, param, param_keys, *args, **kwargs) -> metadata.LfsMetadata:
-        logging.debug(f"Writing Dense update for {'/'.join(param_keys)}")
+        param_name = "/".join(param_keys)
+        logging.debug(f"Writing Dense update for {param_name}")
+        logging.debug(f"Starting Serializing {param_name}")
         serialized = await self.serializer.serialize({"parameter": param})
+        logging.debug(f"Finsihed Serializing {param_name}")
+        logging.debug(f"Starting git-lfs clean for {param_name}")
         lfs_pointer = await git_utils.git_lfs_clean(serialized)
+        logging.debug(f"Finished git-lfs clean for {param_name}")
         return metadata.LfsMetadata.from_pointer(lfs_pointer), None

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -73,7 +73,7 @@ class EnvVar:
 class EnvVarConstants:
     CHECKPOINT_TYPE = EnvVar(name="GIT_THETA_CHECKPOINT_TYPE", default="pytorch")
     UPDATE_TYPE = EnvVar(name="GIT_THETA_UPDATE_TYPE", default="dense")
-    UPDATE_DATA_PATH = EnvVar(name="GIT_THETA_UPDATE_DATA_PATH", default="update.pt")
+    UPDATE_DATA_PATH = EnvVar(name="GIT_THETA_UPDATE_DATA_PATH", default="")
     PARAMETER_ATOL = EnvVar(name="GIT_THETA_PARAMETER_ATOL", default=1e-8)
     PARAMETER_RTOL = EnvVar(name="GIT_THETA_PARAMETER_RTOL", default=1e-5)
     LSH_SIGNATURE_SIZE = EnvVar(name="GIT_THETA_LSH_SIGNATURE_SIZE", default=16)
@@ -81,6 +81,7 @@ class EnvVarConstants:
     LSH_POOL_SIZE = EnvVar(name="GIT_THETA_LSH_POOL_SIZE", default=10_000)
     MAX_CONCURRENCY = EnvVar(name="GIT_THETA_MAX_CONCURRENCY", default=-1)
     MANUAL_MERGE = EnvVar(name="GIT_THETA_MANUAL_MERGE", default=False)
+    LOG_LEVEL = EnvVar(name="GIT_THETA_LOG_LEVEL", default="DEBUG")
 
 
 def flatten(


### PR DESCRIPTION
This PR adds new logging handler classes for Stream (console) and File output that can add async task ids to the logging message. This makes debugging eaiser and lets us group logging messages based on parameter name without needing to pass the actual parameter around all the time.

Additionally, the logging configuration has been unified across all our provided scripts and the env var `GIT_THETA_LOG_LEVEL` can be used to control the level of the logs.

Currently, this all still works by configuring the root logger, eventually we should move to a named logger and only configure that one. That will allow us to do things like log to console and file at different levels.

I also changed the default value for `GIT_THETA_UPDATE_PATH` as the default was triggering an extra smudge, even when using dense updates.