### PR TITLE
Feat/win tempfile

### DIFF
--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -1,6 +1,5 @@
 """Utilities for git theta."""
 
-import contextlib
 import dataclasses
 import datetime
 import functools
@@ -8,7 +7,6 @@ import inspect
 import os
 import re
 import subprocess
-import tempfile
 from dataclasses import dataclass
 from enum import Enum
 from types import MethodType
@@ -304,30 +302,3 @@ def touch(path: str):
     """Update the access and modify time of `path`."""
     dt_epoch = datetime.datetime.now().timestamp()
     os.utime(path, (dt_epoch, dt_epoch))
-
-
-@contextlib.contextmanager
-def named_temporary_file(*args, **kwargs):
-    """A named temp file that is safe to use on windows.
-
-    When using this function to create a named tempfile, it is safe to call
-    operations like `.flush()` and `.close()` on the tempfile which is needed
-    on Windows. Like the normal tempfile context manager, the file is removed
-    automatically when you exit the `with` scope.
-    """
-    # We force these so remove them.
-    m = kwargs.pop("mode", None)
-    if m is not None:
-        raise RuntimeError(
-            f"'mode' argument should not be provided to 'named_temporary_file', got {m}."
-        )
-    d = kwargs.pop("delete", None)
-    if d is not None:
-        raise RuntimeError(
-            f"'delete' argument should not be provided to 'named_temporary_file', got {d}."
-        )
-    with tempfile.NamedTemporaryFile(*args, mode="w", delete=False, **kwargs) as f:
-        try:
-            yield f
-        finally:
-            os.unlink(f.name)

--- a/git_theta/utils.py
+++ b/git_theta/utils.py
@@ -308,7 +308,13 @@ def touch(path: str):
 
 @contextlib.contextmanager
 def named_temporary_file(*args, **kwargs):
-    """A named temp file that is safe to use on windows."""
+    """A named temp file that is safe to use on windows.
+
+    When using this function to create a named tempfile, it is safe to call
+    operations like `.flush()` and `.close()` on the tempfile which is needed
+    on Windows. Like the normal tempfile context manager, the file is removed
+    automatically when you exit the `with` scope.
+    """
     # We force these so remove them.
     m = kwargs.pop("mode", None)
     if m is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,9 @@ profile = "black"
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ["setuptools", "wheel"]  # PEP 508 specifications.
+
+[tool.pytest.ini_options]
+norecursedirs = "tests/helpers tests/end2end"
+testpaths = [
+  "tests"
+]

--- a/tests/checkpoints/safetensors_checkpoint_test.py
+++ b/tests/checkpoints/safetensors_checkpoint_test.py
@@ -2,12 +2,11 @@
 
 import operator as op
 import os
-import tempfile
 
 import numpy as np
 import pytest
 
-from git_theta import checkpoints
+from git_theta import checkpoints, utils
 from git_theta.checkpoints import safetensors_checkpoint
 
 
@@ -22,13 +21,12 @@ def fake_model():
 
 
 def test_round_trip(fake_model):
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+    with utils.named_temporary_file() as f:
         ckpt = safetensors_checkpoint.SafeTensorsCheckpoint(fake_model)
         ckpt.save(f.name)
         f.flush()
         f.close()
         ckpt2 = safetensors_checkpoint.SafeTensorsCheckpoint.from_file(f.name)
-        os.unlink(f.name)
     for (_, og), (_, new) in zip(
         sorted(ckpt.items(), key=op.itemgetter(0)),
         sorted(ckpt2.items(), key=op.itemgetter(0)),

--- a/tests/checkpoints/safetensors_checkpoint_test.py
+++ b/tests/checkpoints/safetensors_checkpoint_test.py
@@ -3,10 +3,11 @@
 import operator as op
 import os
 
+import helpers
 import numpy as np
 import pytest
 
-from git_theta import checkpoints, utils
+from git_theta import checkpoints
 from git_theta.checkpoints import safetensors_checkpoint
 
 
@@ -21,7 +22,7 @@ def fake_model():
 
 
 def test_round_trip(fake_model):
-    with utils.named_temporary_file() as f:
+    with helpers.utils.named_temporary_file() as f:
         ckpt = safetensors_checkpoint.SafeTensorsCheckpoint(fake_model)
         ckpt.save(f.name)
         f.flush()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import os
 import random
 import shutil
 import string
-import tempfile
 
 import git
 import numpy as np

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .utils import *

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,0 +1,32 @@
+"""Helper utilities for unittests."""
+
+import contextlib
+import os
+import tempfile
+
+
+@contextlib.contextmanager
+def named_temporary_file(**kwargs):
+    """A named temp file that is safe to use on windows.
+
+    When using this function to create a named tempfile, it is safe to call
+    operations like `.flush()` and `.close()` on the tempfile which is needed
+    on Windows. Like the normal tempfile context manager, the file is removed
+    automatically when you exit the `with` scope.
+    """
+    # We force these so remove them.
+    m = kwargs.pop("mode", None)
+    if m is not None:
+        raise RuntimeError(
+            f"'mode' argument should not be provided to 'named_temporary_file', got {m}."
+        )
+    d = kwargs.pop("delete", None)
+    if d is not None:
+        raise RuntimeError(
+            f"'delete' argument should not be provided to 'named_temporary_file', got {d}."
+        )
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, **kwargs) as f:
+        try:
+            yield f
+        finally:
+            os.unlink(f.name)

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -2,10 +2,11 @@
 
 import os
 
+import helpers
 import numpy as np
 import pytest
 
-from git_theta import metadata, utils
+from git_theta import metadata
 
 
 def metadata_equal(m1, m2):
@@ -71,7 +72,7 @@ def test_metadata_file_roundtrip(data_generator):
     Test that Metadata serializes to file and can be generated from file correctly
     """
     metadata_obj = data_generator.random_metadata()
-    with utils.named_temporary_file() as tmp:
+    with helpers.utils.named_temporary_file() as tmp:
         metadata_obj.write(tmp)
         tmp.flush()
         tmp.close()

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,12 +1,11 @@
 """Tests for metadata.py"""
 
 import os
-import tempfile
 
 import numpy as np
 import pytest
 
-from git_theta import metadata
+from git_theta import metadata, utils
 
 
 def metadata_equal(m1, m2):
@@ -72,12 +71,11 @@ def test_metadata_file_roundtrip(data_generator):
     Test that Metadata serializes to file and can be generated from file correctly
     """
     metadata_obj = data_generator.random_metadata()
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+    with utils.named_temporary_file() as tmp:
         metadata_obj.write(tmp)
         tmp.flush()
         tmp.close()
         metadata_roundtrip = metadata.Metadata.from_file(tmp.name)
-        os.unlink(tmp.name)
     assert metadata_equal(metadata_obj, metadata_roundtrip)
 
 

--- a/tests/theta_test.py
+++ b/tests/theta_test.py
@@ -3,7 +3,9 @@
 import os
 import random
 
-from git_theta import theta, utils
+import helpers
+
+from git_theta import theta
 
 
 def test_commit_info_serialization(data_generator):
@@ -11,7 +13,7 @@ def test_commit_info_serialization(data_generator):
     Test that CommitInfo objects serialize/deserialize to/from files correctly
     """
     commit_info = data_generator.random_commit_info()
-    with utils.named_temporary_file() as tmpfile:
+    with helpers.utils.named_temporary_file() as tmpfile:
         commit_info.write(tmpfile)
         tmpfile.flush()
         tmpfile.close()

--- a/tests/theta_test.py
+++ b/tests/theta_test.py
@@ -2,9 +2,8 @@
 
 import os
 import random
-import tempfile
 
-from git_theta import theta
+from git_theta import theta, utils
 
 
 def test_commit_info_serialization(data_generator):
@@ -12,12 +11,11 @@ def test_commit_info_serialization(data_generator):
     Test that CommitInfo objects serialize/deserialize to/from files correctly
     """
     commit_info = data_generator.random_commit_info()
-    with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmpfile:
+    with utils.named_temporary_file() as tmpfile:
         commit_info.write(tmpfile)
         tmpfile.flush()
         tmpfile.close()
         commit_info_read = theta.CommitInfo.from_file(tmpfile.name)
-        os.unlink(tmpfile.name)
     assert commit_info == commit_info_read
 
 


### PR DESCRIPTION
The PR adds a wrapper around Python's named temporary file
functionality. When used on windows, there are often permission errors
when trying to open the file by name. As a work around we often open the
tempfile so that it is not deleted after leaving the scope, calling
`.flush()` and `.close()` on it, and then
manually deleting it. This encapsulates that workflow.

This is something we that generally only using during testing, however,
but including it in the main library is the easiest way to import it
in tests. I can figure out a way to move it to the test area if we hate
that.

That PR also updates a few tests to use this new function.