### PR TITLE
Update how `git-theta track ${path}` works.

### DIFF
--- a/.github/workflows/end2endtest.yml
+++ b/.github/workflows/end2endtest.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set Up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8
       # Install package and deps so third-party packages are sorted

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
         - uses: actions/checkout@v2
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: "3.8"
         - name: Install Build Package

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set Up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/git_theta/scripts/git_theta.py
+++ b/git_theta/scripts/git_theta.py
@@ -80,12 +80,12 @@ def post_commit(args):
     theta_commits = theta.ThetaCommits(repo)
 
     gitattributes_file = git_utils.get_gitattributes_file(repo)
-    patterns = git_utils.get_gitattributes_tracked_patterns(gitattributes_file)
+    gitattributes = git_utils.read_gitattributes(gitattributes_file)
 
     oids = set()
     commit = repo.commit("HEAD")
     for path in commit.stats.files.keys():
-        if any([fnmatch.fnmatchcase(path, pattern) for pattern in patterns]):
+        if git_utils.is_theta_tracked(path, gitattributes):
             curr_metadata = metadata.Metadata.from_file(commit.tree[path].data_stream)
             prev_metadata = metadata.Metadata.from_commit(repo, path, "HEAD~1")
 

--- a/tests/git_utils_test.py
+++ b/tests/git_utils_test.py
@@ -8,62 +8,182 @@ from git_theta import git_utils
 
 
 def test_add_theta_gitattributes_empty_file():
-    assert git_utils.add_theta_to_gitattributes([], "example") == [
+    assert list(map(str, git_utils.add_theta_to_gitattributes([], "example"))) == [
         "example filter=theta merge=theta diff=theta"
     ]
 
 
+def test_is_theta_tracked_with_override():
+    attrs = [
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "mymodel.pt filter=theta merge=theta diff=theta",
+            "*.pt filter=theta merge=theta diff=theta",
+        )
+    ]
+    print(attrs)
+    assert git_utils.is_theta_tracked("mymodel.pt", attrs)
+
+
+def test_is_theta_tracked_with_override_false():
+    attrs = [
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "mymodel.pt filter=theta merge=theta diff=theta",
+            "*.pt filter=lfs merge=theta diff=lfs",
+        )
+    ]
+    assert git_utils.is_theta_tracked("mymodel.pt", attrs) == False
+
+
+def test_is_theta_tracked_no_lines():
+    assert git_utils.is_theta_tracked("mymodel.pt", []) == False
+
+
+def test_is_theta_tracked_no_attrs():
+    assert (
+        git_utils.is_theta_tracked(
+            "mymodel.pt", [git_utils.parse_gitattributes("mymodel.pt")]
+        )
+        == False
+    )
+
+
+def test_is_theta_tracked_with_following_filter():
+    attrs = [
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "mymodel.pt filter=theta merge=theta diff=theta",
+            "*.pt filter=theta filter=lfs merge=lfs diff=lfs",
+        )
+    ]
+    assert git_utils.is_theta_tracked("mymodel.pt", attrs) == False
+
+
+def test_parse_gitattributes_uses_last():
+    attr = git_utils.parse_gitattributes("example.txt merge=theta merge=wrong")
+    assert attr.attributes["merge"] == "wrong"
+
+
+def test_parse_gitattributes_no_equal():
+    s = "example.txt thing"
+    attr = git_utils.parse_gitattributes(s)
+    assert attr.attributes == {"thing": None}
+    assert str(attr) == s
+
+
+def test_parse_gitattributes_raw_string():
+    og_string = "example.txt merge=theta merge=wrong"
+    attr = git_utils.parse_gitattributes(og_string)
+    assert str(attr) == og_string
+    attr.raw = None
+    assert str(attr) == "example.txt merge=wrong"
+
+
 def test_add_theta_gitattributes_no_match():
+    # Should add a new path
     atts = [
-        "Some-other-path filter=lfs",
-        "*-cool-models.pt filter=theta merge=theta diff=theta",
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "Some-other-path filter=lfs",
+            "*-cool-models.pt filter=theta merge=theta diff=theta",
+        )
     ]
     model_path = "path/to/my/model.pt"
     assert (
-        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+        str(git_utils.add_theta_to_gitattributes(atts, model_path)[-1])
         == f"{model_path} filter=theta merge=theta diff=theta"
     )
 
 
-def test_add_theta_gitattributes_exact_match():
+def test_add_theta_gitattributes_exact_match_with_conflicting_attributes():
     model_path = "really/cool/model/yall.ckpt"
-    atts = [f"{model_path} filter=lfs"]
-    assert (
-        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
-        == f"{model_path} filter=lfs filter=theta merge=theta diff=theta"
-    )
+    atts = [git_utils.parse_gitattributes(f"{model_path} filter=lfs")]
+    with pytest.raises(ValueError):
+        new_attributes = git_utils.add_theta_to_gitattributes(atts, model_path)
 
 
-def test_add_theta_gitattributes_pattern_match():
+def test_add_theta_gitattributes_pattern_match_with_conflicting_attributes():
     model_path = "literal-the-best-checkpoint.pt"
-    atts = ["*.pt thing"]
-    assert (
-        git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
-        == f"*.pt thing filter=theta merge=theta diff=theta"
-    )
+    atts = [git_utils.parse_gitattributes("*.pt thing merge=lfs")]
+    with pytest.raises(ValueError):
+        new_attributes = git_utils.add_theta_to_gitattributes(atts, model_path)
 
 
-def test_add_theta_gitattributes_multiple_matches():
-    model_path = "100-on-mnist.npy"
-    atts = ["*.npy other-filter", f"{model_path} other-filter"]
-    assert git_utils.add_theta_to_gitattributes(atts, model_path) == [
-        f"{attr} filter=theta merge=theta diff=theta" for attr in atts
+def test_add_theta_gitattributes_exact_match_disjoint_attributes():
+    # Should create a new attribute with values copied over
+    model_path = "my-test_model"
+    atts = [
+        git_utils.parse_gitattributes(a)
+        for a in ("my-test_model merge=theta diff=theta banana=fruit",)
     ]
+    new_att = git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+    assert new_att.attributes["banana"] == "fruit"
+    assert new_att.attributes["filter"] == "theta"
+
+
+def test_add_theta_gitattributes_pattern_disjoint_attributes():
+    # Should create a new attribute with values copied over
+    model_path = "my-test_model"
+    atts = [
+        git_utils.parse_gitattributes(a)
+        for a in ("my-test* merge=theta diff=theta banana=fruit",)
+    ]
+    new_att = git_utils.add_theta_to_gitattributes(atts, model_path)[-1]
+    assert new_att.pattern == model_path
+    assert new_att.attributes["banana"] == "fruit"
+    assert new_att.attributes["filter"] == "theta"
+
+
+def test_add_theta_gitattributes_disjoint_attributes_multiple_matches():
+    # Should create a new attribute with values copied over
+    model_path = "100-on-mnist.npy"
+    atts = [
+        git_utils.parse_gitattributes(a)
+        for a in ("*.npy other-filter", f"{model_path} target-filter")
+    ]
+    new_attributes = git_utils.add_theta_to_gitattributes(atts, model_path)
+    # Note: target-filter is expected rather than other-filter because the *last*
+    # filter in the file is the active one.
+    assert (
+        str(new_attributes[-1])
+        == f"{model_path} target-filter filter=theta merge=theta diff=theta"
+    )
 
 
 def test_add_theta_gitattributes_match_with_theta_already():
+    # Should be a no-op
     model_path = "my-bad-model.chkp"
-    atts = ["my-*-model.chkp filter=theta merge=theta diff=theta"]
-    assert git_utils.add_theta_to_gitattributes(atts, model_path) == atts
+    atts = [
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "my-*-model.chkp filter=theta merge=theta diff=theta",
+            "example.txt thing",
+        )
+    ]
+    new_attributes = git_utils.add_theta_to_gitattributes(atts, model_path)
+    assert new_attributes == atts
+
+
+# This should fail until unsetting attributes are handled.
+@pytest.mark.xfail
+def test_add_theta_gitattributes_unset_diff():
+    # The attribute represention (the dict) my change when unsetting is implemented.
+    attr = git_utils.GitAttributes("example.pt", {"-diff": None})
+    with pytest.raises(ValueError):
+        new_attributes = git_utils.add_theta_to_gitattributes([attr], "example.pt")
 
 
 def test_add_theta_gitattributes_rest_unchanged():
     model_path = "model-v3.pt"
     atts = [
-        "some-other-path filter=theta merge=theta diff=theta",
-        "really-reaaaally-big-files filter=lfs",
-        r"model-v\d.pt filter",
-        "another filter=theta merge=theta diff=theta",
+        git_utils.parse_gitattributes(a)
+        for a in (
+            "some-other-path filter=theta merge=theta diff=theta",
+            "really-reaaaally-big-files filter=lfs",
+            r"model-v\d.pt filter",
+            "another filter=theta merge=theta diff=theta",
+        )
     ]
     results = git_utils.add_theta_to_gitattributes(atts, model_path)
     for i, (a, r) in enumerate(zip(atts, results)):
@@ -78,18 +198,25 @@ def gitattributes():
         "*.pt filter=theta merge=theta diff=theta",
         "*.png filter=lfs",
         "really-big-file filter=lfs",
-        "something else, who knows how cool it could be",
+        "something else",
+    ], [
+        git_utils.GitAttributes(
+            "*.pt", {"filter": "theta", "merge": "theta", "diff": "theta"}
+        ),
+        git_utils.GitAttributes("*.png", {"filter": "lfs"}),
+        git_utils.GitAttributes("really-big-file", {"filter": "lfs"}),
+        git_utils.GitAttributes("something", {"else": None}),
     ]
 
 
 def test_read_gitattributes(gitattributes, tmp_path):
     """Test that reading gitattributes removes newlines."""
+    attributes_text, gitattributes = gitattributes
     gitattributes_file = tmp_path / ".gitattributes"
     with open(gitattributes_file, "w") as wf:
-        wf.write("\n".join(gitattributes))
+        wf.write("\n".join(attributes_text))
     read_attributes = git_utils.read_gitattributes(gitattributes_file)
-    for attr in read_attributes:
-        assert not attr.endswith("\n")
+    assert read_attributes == gitattributes
 
 
 def test_read_gitattributes_missing_file(tmp_path):
@@ -111,6 +238,7 @@ def test_read_gitattributes_empty_file(tmp_path):
 
 def test_write_gitattributes(gitattributes, tmp_path):
     """Test that attributes are written to file unchanged and include newlines."""
+    gitattributes = gitattributes[0]
     attr_file = tmp_path / ".gitattributes"
     for attr in gitattributes:
         assert not attr.endswith("\n")
@@ -141,8 +269,9 @@ def test_write_gitattributes_creates_file(gitattributes, tmp_path):
 
 def test_read_write_gitattributes_write_read_round_trip(gitattributes, tmp_path):
     """Test that we can write attributes, then read them back and they will match."""
+    attributes_text, gitattributes = gitattributes
     attr_file = tmp_path / ".gitattributes"
-    git_utils.write_gitattributes(attr_file, gitattributes)
+    git_utils.write_gitattributes(attr_file, attributes_text)
     read_attrs = git_utils.read_gitattributes(attr_file)
     assert read_attrs == gitattributes
 


### PR DESCRIPTION
Currently, when a pattern in `.gitattributes` matches the path in `git-theta track`, the theta attributes (filter, merge, diff) are added to that line. This can cause issues as it may result in tracking more files with git-theta than expected.

However, just adding a new line that is an exact match for the path to the end of the gitattribute file is not correct either. The *last* attribute line in the file is the one used by Git. This could result in `git-theta track` removing an some other attribute that is set for that file.

This PR updates the way that git attributes are set. A new line that is an exact match to the current path is added, the currently active attributes are copied over, and the new theta attributes are added.

When a line has an attribute set multiple times, the *last* one is used so we can add the theta filters at the end to override any previous ones.

Note that with this PR running `git-theta track` on the same file multiple times it will keep adding lines to `.gitattributes`.

This change is based on a comment in https://github.com/r-three/git-theta/pull/214

This also adds a `is_theta_tracked` function. (I meant to make it in a different branch lol)

This change is based on a part of
https://github.com/r-three/git-theta/pull/214 where the test for if a
file is tracked by Git-Theta is abstracted into a function.

However it is implemented differently as it now handles the subtleties of
what attribute line is active at a given time.

Only the final line that a path matches is used to set attributes and
only the last entry for some key is used. This is now respected.****