### PR TITLE
Move to a named logger.

### DIFF
--- a/git_theta/filters.py
+++ b/git_theta/filters.py
@@ -31,13 +31,14 @@ def clean(
     prev_metadata = metadata.Metadata.from_commit(repo, path, "HEAD").flatten()
 
     async def _clean(param_keys, new_param):
-        logging.debug(f"Cleaning {'/'.join(param_keys)}")
+        logger = logging.getLogger("git_theta")
+        logger.debug(f"Cleaning {'/'.join(param_keys)}")
         # Get the metadata from the previous version of the parameter
         param_metadata = prev_metadata.get(param_keys)
         # Create new metadata from the current value
-        logging.debug(f"Making new Metadata for {'/'.join(param_keys)}")
+        logger.debug(f"Making new Metadata for {'/'.join(param_keys)}")
         new_tensor_metadata = metadata.TensorMetadata.from_tensor(new_param)
-        logging.debug(f"Finished new Metadata for {'/'.join(param_keys)}")
+        logger.debug(f"Finished new Metadata for {'/'.join(param_keys)}")
 
         # If the parameter tensor has not changed, just keep the metadata the same
         # TODO: Encapsulate this parameter check within an equality check.
@@ -53,7 +54,7 @@ def clean(
             # Compare the parameters using the LSH
             hasher = lsh.get_lsh()
             # TODO: Is is possible to make this comparison async?
-            logging.debug(f"Comparing Hashes for: {'/'.join(param_keys)}")
+            logger.debug(f"Comparing Hashes for: {'/'.join(param_keys)}")
             hash_distance = hasher.distance(
                 param_metadata.tensor_metadata.hash, new_tensor_metadata.hash
             )
@@ -102,7 +103,7 @@ def clean(
             tensor_metadata=new_tensor_metadata,
             theta_metadata=new_theta_metadata,
         )
-        logging.debug(f"Finished Cleaning {'/'.join(param_keys)}")
+        logger.debug(f"Finished Cleaning {'/'.join(param_keys)}")
         return param_keys, new_param_metadata
 
     # Sort the keys so we don't get changing diffs based on serialization order.
@@ -127,7 +128,8 @@ def smudge(
     curr_metadata = cleaned_metadata.flatten()
 
     async def _smudge(param_keys, param_metadata):
-        logging.debug(f"Smudging {'/'.join(param_keys)}")
+        logger = logging.getLogger("git_theta")
+        logger.debug(f"Smudging {'/'.join(param_keys)}")
         update_handler = updates.get_update_handler(
             param_metadata.theta_metadata.update_type
         )(params.get_update_serializer())

--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -306,7 +306,8 @@ def add_file(f, repo):
     repo : git.Repo
         Repo object for current git repository
     """
-    logging.debug(f"Adding {f} to staging area")
+    logger = logging.getLogger("git_theta")
+    logger.debug(f"Adding {f} to staging area")
     repo.git.add(f)
 
 
@@ -321,7 +322,8 @@ def remove_file(f, repo):
     repo : git.Repo
         Repo object for current git repository
     """
-    logging.debug(f"Removing {f}")
+    logger = logging.getLogger("git_theta")
+    logger.debug(f"Removing {f}")
     if os.path.isdir(f):
         repo.git.rm("-r", f)
     else:

--- a/git_theta/merges/base.py
+++ b/git_theta/merges/base.py
@@ -77,7 +77,8 @@ class Merge(metaclass=PrintableABCMeta):
     ] = frozenset()  # States where this action will not appear in the menu.
 
     def __call__(self, param_name, *args, **kwargs):
-        logging.info(f"Running {self.NAME} merge on parameter {'/'.join(param_name,)}")
+        logger = logging.getLogger("git_theta")
+        logger.info(f"Running {self.NAME} merge on parameter {'/'.join(param_name,)}")
         return self.merge(param_name, *args, **kwargs)
 
     @abstractmethod

--- a/git_theta/metadata.py
+++ b/git_theta/metadata.py
@@ -74,9 +74,10 @@ class TensorMetadata(MetadataField):
     def from_tensor(cls, tensor: np.ndarray) -> TensorMetadata:
         shape = str(tensor.shape)
         dtype = str(tensor.dtype)
-        logging.debug(f"Starting LSH Hash")
+        logger = logging.getLogger("git_theta")
+        logger.debug(f"Starting LSH Hash")
         hash = lsh.get_lsh().hash(tensor)
-        logging.debug(f"Finished LSH Hash")
+        logger.debug(f"Finished LSH Hash")
         return cls(shape=shape, dtype=dtype, hash=hash)
 
 

--- a/git_theta/scripts/__init__.py
+++ b/git_theta/scripts/__init__.py
@@ -7,22 +7,43 @@ logging if git_theta is being used as a library.
 import logging
 import os
 import tempfile
+from typing import Optional
 
 import git_theta
 
 
-def configure_logging(exe_name: str):
-    format_str = f"{exe_name}: [%(asctime)s] [task %(task)s] [%(funcName)s] %(levelname)s - %(message)s"
-    logging.basicConfig(
-        level=getattr(
-            logging, git_theta.utils.EnvVarConstants.LOG_LEVEL.upper(), logging.DEBUG
-        ),
-        # Log to a file for clean/smudge as they don't appear on the console when called via git.
-        format=format_str,
-        handlers=[
-            git_theta.async_utils.AsyncTaskStreamHandler(),
-            git_theta.async_utils.AsyncTaskFileHandler(
-                filename=os.path.join(tempfile.gettempdir(), "git-theta.log")
-            ),
-        ],
+def configure_logging(
+    exe_name: str, logger_name: str = "git_theta", root: Optional[str] = None
+):
+    logger = logging.getLogger(logger_name)
+    format_str = f"{exe_name}: [%(asctime)s] [%(task)s] [%(package)s:%(funcName)s] %(levelname)s - %(message)s"
+    log_level = getattr(
+        logging, git_theta.utils.EnvVarConstants.LOG_LEVEL.upper(), logging.DEBUG
     )
+    logger.setLevel(log_level)
+    formatter = logging.Formatter(fmt=format_str)
+
+    root = (
+        os.path.dirname(os.path.dirname(git_theta.__file__)) if root is None else root
+    )
+
+    def log_filter(record: logging.LogRecord) -> logging.LogRecord:
+        package = record.pathname[len(root) + 1 :]
+        if package.endswith(".py"):
+            package = package[:-3]
+        record.package = package.replace(os.sep, ".")
+        return record
+
+    handlers = (
+        git_theta.async_utils.AsyncTaskStreamHandler(),
+        git_theta.async_utils.AsyncTaskFileHandler(
+            filename=os.path.join(tempfile.gettempdir(), "git-theta.log")
+        ),
+    )
+    for handler in handlers:
+        handler.setLevel(log_level)
+        handler.setFormatter(formatter)
+        handler.addFilter(log_filter)
+        logger.addHandler(handler)
+
+    return logger

--- a/git_theta/scripts/git_theta_filter.py
+++ b/git_theta/scripts/git_theta_filter.py
@@ -35,7 +35,8 @@ def run_clean(args):
     """
     Implements clean filter for model files
     """
-    logging.debug(f"Running clean filter on {args.file}")
+    logger = logging.getLogger("git_theta")
+    logger.debug(f"Running clean filter on {args.file}")
     repo = git_utils.get_git_repo()
     checkpoint_handler = checkpoints.get_checkpoint_handler()
     model_checkpoint = checkpoint_handler.from_file(sys.stdin.buffer)
@@ -51,7 +52,8 @@ def run_smudge(args):
     """
     Implements smudge filter for model files
     """
-    logging.debug(f"Running smudge filter on {args.file}")
+    logger = logging.getLogger("git_theta")
+    logger.debug(f"Running smudge filter on {args.file}")
 
     repo = git_utils.get_git_repo()
     curr_metadata = metadata.Metadata.from_file(sys.stdin)

--- a/git_theta/scripts/git_theta_merge.py
+++ b/git_theta/scripts/git_theta_merge.py
@@ -126,7 +126,8 @@ def make_short_cuts(
         # B = short_cut is free
         if handler.SHORT_CUT in reserved:
             # Triggers for [A ∧ B, A ∧ ¬B]
-            logging.warning(
+            logger = logging.getLogger("git_theta")
+            logger.warning(
                 f"Merge Plug-in {handler.NAME} requested short-cut"
                 f" {handler.SHORT_CUT} which is reserved."
             )
@@ -170,7 +171,8 @@ def build_menu(
 
 
 def manual_merge(args):
-    logging.info(f"Writing model weights from {args.path} for manual merging.")
+    logger = logging.getLogger("git_theta")
+    logger.info(f"Writing model weights from {args.path} for manual merging.")
 
     # TODO: Update smudge API to make it easier to call programatically.
     async def load(name, path):
@@ -193,9 +195,9 @@ def manual_merge(args):
     checkpoints = async_utils.run(async_utils.run_map(checkpoints, load))
     for name, raw_weights in checkpoints.items():
         with open(f"{name}.ckpt", "wb") as wf:
-            logging.info(f"Saving {name} model to {name}.ckpt")
+            logger.info(f"Saving {name} model to {name}.ckpt")
             wf.write(raw_weights)
-    logging.info(
+    logger.info(
         "Manual Merging: Combine checkpoints as you wish, save the "
         f"result to {args.path} and continue the merge."
     )
@@ -204,10 +206,11 @@ def manual_merge(args):
 
 def merge(args):
     """git-theta checkpoint aware merging."""
+    logger = logging.getLogger("git_theta")
     print_formatted_text(
         HTML(f"<b>Fixing Merge Conflicts in {TEXT_STYLE.format_model(args.path)}</b>")
     )
-    logging.debug(f"Running merge driver on {args.path}")
+    logger.debug(f"Running merge driver on {args.path}")
     # Load the `cleaned` metadata file for the ancestor commit.
     ancestor = metadata.Metadata.from_file(args.ancestor)
     ancestor = ancestor.flatten()
@@ -255,14 +258,14 @@ def merge(args):
         # Changes that don't need human action to be resolved.
         # If the parameter is unchanged between all models just use it.
         if state is DiffState.EQUAL:
-            logging.debug(
+            logger.debug(
                 f"Parameter {name} was unchanged by either branch. "
                 "Keeping the value the same going forward."
             )
             merged_model[param_name] = ancestor_param
             continue
         if state is DiffState.DELETED_BOTH:
-            logging.debug(
+            logger.debug(
                 f"Parameter {name} was deleted on both branches. "
                 "Removing from the merged result."
             )
@@ -315,9 +318,9 @@ def merge(args):
                 complete_while_typing=True,
             )
             action = action.strip()
-            logging.debug(f"User Input: {action}")
+            logger.debug(f"User Input: {action}")
             if action == "q":
-                logging.debug(
+                logger.debug(
                     "User quit the merge tool. Leaving merge files as they are."
                 )
                 sys.exit(1)

--- a/git_theta/theta.py
+++ b/git_theta/theta.py
@@ -38,6 +38,7 @@ class ThetaCommits:
         self.repo = repo
         self.path = os.path.abspath(os.path.join(repo.git_dir, "theta", "commits"))
         os.makedirs(self.path, exist_ok=True)
+        self.logger = logging.getLogger("git_theta")
 
     @staticmethod
     def combine_oid_sets(oid_sets):
@@ -56,7 +57,7 @@ class ThetaCommits:
         return commit
 
     def get_commit_info_range(self, start_hash, end_hash):
-        logging.debug(f"Getting commits from {start_hash}..{end_hash}")
+        self.logger.debug(f"Getting commits from {start_hash}..{end_hash}")
         # N.b. the all-zero hash is used by git to indicate a non-existent start hash
         # For example, a git pre-push hook will receive the all-zero hash if the remote ref does not have any commit history
         if re.match("^0{40}$", start_hash):
@@ -64,24 +65,24 @@ class ThetaCommits:
         else:
             commits = list(self.repo.iter_commits(f"{start_hash}..{end_hash}"))
 
-        logging.debug(f"Found commits {commits}")
+        self.logger.debug(f"Found commits {commits}")
         commit_infos = [self.get_commit_info(commit.hexsha) for commit in commits]
         return commit_infos
 
     def get_commit_oids(self, commit_hash):
-        logging.debug(f"Getting oids from commit {commit_hash}")
+        self.logger.debug(f"Getting oids from commit {commit_hash}")
         commit_info = self.get_commit_info(commit_hash)
         oids = commit_info.oids
-        logging.debug(f"Found oids {oids}")
+        self.logger.debug(f"Found oids {oids}")
         return oids
 
     def get_commit_oids_range(self, start_hash, end_hash):
-        logging.debug(f"Getting oids from commit range {start_hash}..{end_hash}")
+        self.logger.debug(f"Getting oids from commit range {start_hash}..{end_hash}")
         commit_infos = self.get_commit_info_range(start_hash, end_hash)
         oids = ThetaCommits.combine_oid_sets(
             [commit_info.oids for commit_info in commit_infos]
         )
-        logging.debug(f"Found oids {oids}")
+        self.logger.debug(f"Found oids {oids}")
         return oids
 
     def get_commit_oids_ranges(self, *ranges):
@@ -92,7 +93,7 @@ class ThetaCommits:
         return ThetaCommits.combine_oid_sets(oids)
 
     def write_commit_info(self, commit_hash, commit_info):
-        logging.debug(f"Writing commit_info to commit {commit_hash}")
+        self.logger.debug(f"Writing commit_info to commit {commit_hash}")
         if not utils.is_valid_commit_hash(commit_hash):
             raise ValueError(f"Cannot write commit info for invalid hash {commit_hash}")
         path = self.get_commit_path(commit_hash)

--- a/git_theta/updates/dense.py
+++ b/git_theta/updates/dense.py
@@ -16,21 +16,22 @@ class DenseUpdate(Update):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger("git_theta")
 
     async def apply(self, param_metadata, param_keys, *args, **kwargs) -> Parameter:
         param_name = "/".join(param_keys)
-        logging.debug(f"Reading Dense update for {param_name}")
+        self.logger.debug(f"Reading Dense update for {param_name}")
         tensor = await self.read(param_metadata)
-        logging.debug(f"Finished Read Dense update for {param_name}")
+        self.logger.debug(f"Finished Read Dense update for {param_name}")
         return tensor
 
     async def write(self, param, param_keys, *args, **kwargs) -> metadata.LfsMetadata:
         param_name = "/".join(param_keys)
-        logging.debug(f"Writing Dense update for {param_name}")
-        logging.debug(f"Starting Serializing {param_name}")
+        self.logger.debug(f"Writing Dense update for {param_name}")
+        self.logger.debug(f"Starting Serializing {param_name}")
         serialized = await self.serializer.serialize({"parameter": param})
-        logging.debug(f"Finished Serializing {param_name}")
-        logging.debug(f"Starting git-lfs clean for {param_name}")
+        self.logger.debug(f"Finished Serializing {param_name}")
+        self.logger.debug(f"Starting git-lfs clean for {param_name}")
         lfs_pointer = await git_utils.git_lfs_clean(serialized)
-        logging.debug(f"Finished git-lfs clean for {param_name}")
+        self.logger.debug(f"Finished git-lfs clean for {param_name}")
         return metadata.LfsMetadata.from_pointer(lfs_pointer), None

--- a/git_theta/updates/low_rank.py
+++ b/git_theta/updates/low_rank.py
@@ -40,14 +40,15 @@ class LowRankUpdate(IncrementalUpdate):
         update = parameter - previous_parameter
         if update.ndim < 2:
             return update
-        logging.info("Inferring low-rank update based on SVD")
+        logger = logging.getLogger("git_theta")
+        logger.info("Inferring low-rank update based on SVD")
         u, s, vh = np.linalg.svd(update, full_matrices=False)
         if self.K is not None:
             k = self.K
-            logging.info(f"Low Rank Update configured to have a rank of {k}")
+            logger.info(f"Low Rank Update configured to have a rank of {k}")
         else:
             k = np.sum(s > self.threshold)
-            logging.info(f"Low Rank Update inferred to have a rank of {k}")
+            logger.info(f"Low Rank Update inferred to have a rank of {k}")
         return {"R": u[:, :k], "C": (np.diag(s[:k]) @ vh[:k, :])}
 
     async def apply_update(self, update: Parameter, previous: Parameter) -> Parameter:


### PR DESCRIPTION
Move to a logger named `git_theta` so that we don't edit the default logger which causes other libraries we use to output all of there logs too.

Now only git-theta logs get output unless other loggers are configured.