### PR TITLE
Check the error code for `git lfs smudge`

### DIFF
--- a/git_theta/git_utils.py
+++ b/git_theta/git_utils.py
@@ -16,6 +16,7 @@ from typing import Dict, List, Optional, Sequence, Union
 
 import git
 import gitdb
+import six
 
 # TODO(bdlester): importlib.resources doesn't have the `.files` API until python
 # version `3.9` so use the backport even if using a python version that has
@@ -377,6 +378,8 @@ async def git_lfs_smudge(pointer_file: str) -> bytes:
         input=pointer_file.encode("utf-8"),
         capture_output=True,
     )
+    if out.returncode != 0:
+        raise ValueError(f"git lfs smudge failed with: {six.ensure_text(out.stderr)}")
     return out.stdout
 
 


### PR DESCRIPTION
Currently our git lfs smudge runner never checked the error code. This lead to a weird error where when git lfs smudge failed, the stdout was set to the stdin. Thus the lfs pointer file contents was passed along until it caused an error in the msgpack decoding. This PR updates out git lfs runner to check the return code and raise an error if it is non-zero. This makes the error message much more understandable.