### PR TITLE
Update matrix of options to support macos again.

### DIFF
--- a/.github/workflows/end2endtest.yml
+++ b/.github/workflows/end2endtest.yml
@@ -16,10 +16,20 @@ jobs:
       run:
         shell: bash
     strategy:
-      max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest] # macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+        - os: macos-latest
+          python-version: "3.8"
+        - os: macos-latest
+          python-version: "3.9"
+        - os: macos-latest
+          python-version: "3.10"
+        - os: macos-13
+          python-version: "3.11"
+        - os: macos-13
+          python-version: "3.12"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,10 +16,20 @@ jobs:
       run:
         shell: bash
     strategy:
-      max-parallel: 12
       matrix:
-        os: [ubuntu-latest, windows-latest] # macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+        - os: macos-latest
+          python-version: "3.8"
+        - os: macos-latest
+          python-version: "3.9"
+        - os: macos-latest
+          python-version: "3.10"
+        - os: macos-13
+          python-version: "3.11"
+        - os: macos-13
+          python-version: "3.12"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The new versions of MacOS Runners are ARM based and the setup-python action doesn't support older python versions (before 3.11) on ARM.

This PR updates the matrix to include both macos-latest (arm) and macos-13 (the last x86_64 version). It then use excludes to only run new python versions on ARM and older versions of x86.

We miss out on coverage of someone compiling their own version of < 3.11 python on apple silicon, but I don't think that's too much of an issue.

If we ever need to bump the minimum python version beyond 3.11 we can remove this.

It also removes the parallelism limiters on the matrix computation (not sure why I added that, GitHub lets you have infinite parallel runners for now lol).

closes https://github.com/r-three/git-theta/issues/245